### PR TITLE
Revert "[npm] update to latest version"

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -76,7 +76,6 @@ RUN /bin/bash -l -c "\
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default \
-    && npm install -g npm@latest \
     && npm config set python /usr/bin/python --global \
     && npm config set python /usr/bin/python"
 


### PR DESCRIPTION
Reverts gitpod-io/workspace-images#7
I see
```
nvm is not compatible with the npm config "prefix" option: currently set to "/usr/local"
Run `npm config delete prefix` or `nvm use --delete-prefix v8.11.3 --silent` to unset it.
```