### PR TITLE
Revert "add libcurl3"

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update --fix-missing \
     && apt-get install -y \
       sudo \
       curl \
-      libcurl3 \
       build-essential \
       libssl-dev \
       vim \


### PR DESCRIPTION
This reverts commit cbfc35689168bdc5d7f991ef4604ad663572dde8.

There is a conflict of libcurl3 and libcurl4.