### PR TITLE
Remove unnecessary ad-hoc Python installation

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -126,16 +126,18 @@ RUN curl -fsSL https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install
         && npm install -g typescript"
 
 ### Python ###
-ARG PYENV_ROOT=$HOME/.pyenv
-RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    # 'system' Python >= 3.6 for Python language server
+RUN sudo apt-get update && sudo apt-get install -yq \
+        python3-pip \
+        virtualenv \
+    && pip3 install python-language-server[all]==0.19.0 \
+    # pyenv version manager for users
+    && curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && { echo; \
-        echo PATH=$PYENV_ROOT/bin:'$PATH'; \
+        echo 'PATH=~/.pyenv/bin:$PATH'; \
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> .bashrc \
-    && $PYENV_ROOT/bin/pyenv install 3.6.6 \
-    && $PYENV_ROOT/bin/pyenv global 3.6.6 \
-    && $PYENV_ROOT/shims/pip install virtualenv python-language-server[all]==0.19.0 \
-    && rm -rf /tmp/*
+    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/*
 
 ### Ruby ###
 ENV RUBY_VERSION=2.5.3


### PR DESCRIPTION
Fixes #38.

It seems that our explicitely installed Python 3.6.6 via `pyenv` is unnecessary as there's already Python 3.6.7 in the system.

This PR removes it (though leaves `pyenv` in place for the convenience of our users).

Checked the layers size (`python-pip` package pulls half of Ubuntu repository in ;p) and:
  * before, the whole Python part measured 207 MB
  * now it would be 78 MB for `python-pip` + 3.48 MB `pyenv` + 17.2 MB the language server.
So half the size

Caveat: we must check that this way installed language server still works for our purposes.