### PR TITLE
Install htop

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -6,6 +6,7 @@ RUN yes | unminimize \
         asciidoctor \
         bash-completion \
         build-essential \
+        htop \
         jq \
         less \
         llvm \


### PR DESCRIPTION
I much prefer it over `top`, and it has an installed size of "only" [225.0 kB](https://packages.debian.org/sid/htop).