### PR TITLE
Install python-dev for all workspaces

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -134,7 +134,8 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pyenv install 3.6.6 \
     && pyenv global 3.6.6 \
     && pip install virtualenv pipenv python-language-server[all]==0.19.0 \
-    && rm -rf /tmp/*
+    && sudo apt-get update && sudo apt-get install -yq python-dev \
+    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/*
 
 ### Ruby ###
 ENV RUBY_VERSION=2.6.0


### PR DESCRIPTION
~~Installing `pipenv` fixes #45.~~ (Merged separately: d4faa664f4e6def348a5e4b59921996a13b31f38)

Installing `python-dev` ~~and `python3-dev`~~ fixes issues like `fatal error: Python.h: No such file or directory` that sometimes happen when developing in Python using Gitpod.