### PR TITLE
Dynamically fetch rvm.io GPG keys

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -138,8 +138,8 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
 
 ### Ruby ###
 ENV RUBY_VERSION=2.6.0
-RUN gpg --keyserver hkp://keys.gnupg.net \
-        --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \
+    && curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \


### PR DESCRIPTION
Replace fix keys for rvm.io with dynamically fetched ones following https://rvm.io/rvm/security#alternatives.