### PR TITLE
Build and deploy images using CircleCI

### DIFF
--- a/.circleci/build_image.sh
+++ b/.circleci/build_image.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -xe
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 DOCKERFILE IMAGE_NAME"
+  exit 2
+fi
+
+DIR=`dirname $1`
+DOCKERFILE=$1
+IMAGE_NAME=$2
+
+docker build -t $IMAGE_NAME -f $DOCKERFILE $DIR
+
+if [[ ! -z $DOCKER_USER ]]; then
+  # Log in to Docker Hub.
+  # Use heredoc to avoid variable getting exposed in trace output.
+  # Use << (<<< herestring is not available in busybox ash).
+  docker login -u $DOCKER_USER --password-stdin << EOF
+$DOCKER_PASS
+EOF
+  # Decide whether Docker Hub images should be tagged ":branch-Y" or ":latest".
+  if [[ $CIRCLE_BRANCH != "master" ]]; then
+    DOCKERHUB_TAG="branch-$CIRCLE_BRANCH"
+  else
+    DOCKERHUB_TAG="latest"
+  fi
+  docker tag $IMAGE_NAME $IMAGE_NAME:$DOCKERHUB_TAG
+  docker push $IMAGE_NAME:$DOCKERHUB_TAG
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+version: 2.0
+
+jobs:
+  workspace-full:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: |
+            ./.circleci/build_image.sh full/Dockerfile gitpod/workspace-full
+            docker save gitpod/workspace-full -o workspace-full.tar
+      - persist_to_workspace:
+          root: .
+          paths:
+            - workspace-full.tar
+
+  workspace-full-vnc:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            docker load -i workspace-full.tar
+            ./.circleci/build_image.sh full-vnc/Dockerfile gitpod/workspace-full-vnc
+            docker save gitpod/workspace-full-vnc -o workspace-full-vnc.tar
+      - persist_to_workspace:
+          root: .
+          paths:
+            - workspace-full-vnc.tar
+
+  mdbook:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            docker load -i workspace-full.tar
+            ./.circleci/build_image.sh mdbook/Dockerfile gitpod/mdbook
+
+  workspace-dotnet:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            docker load -i workspace-full.tar
+            ./.circleci/build_image.sh dotnet/Dockerfile gitpod/workspace-dotnet
+
+  workspace-dotnet-vnc:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            docker load -i workspace-full-vnc.tar
+            ./.circleci/build_image.sh dotnet-vnc/Dockerfile gitpod/workspace-dotnet-vnc
+
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - workspace-full
+      - workspace-full-vnc:
+          requires:
+            - workspace-full
+      - mdbook:
+          requires:
+            - workspace-full
+      - workspace-dotnet:
+          requires:
+            - workspace-full
+      - workspace-dotnet-vnc:
+          requires:
+            - workspace-full-vnc


### PR DESCRIPTION
This is based on the configuration we use to build and publish images in https://github.com/JanitorTechnology/dockerfiles.

It builds quite fast, and organizes builds into nice dependency trees:

<img width="480" alt="screenshot 2019-01-24 at 15 23 08" src="https://user-images.githubusercontent.com/599268/51684355-28471200-1fec-11e9-953e-d0e4d2a90f77.png">

Many thanks for writing that build script @ishitatsuyuki! 💯 