### PR TITLE
[circleci] Support building branch names with '/'

### DIFF
--- a/.circleci/build_image.sh
+++ b/.circleci/build_image.sh
@@ -21,7 +21,7 @@ $DOCKER_PASS
 EOF
   # Decide whether Docker Hub images should be tagged ":branch-Y" or ":latest".
   if [[ $CIRCLE_BRANCH != "master" ]]; then
-    DOCKERHUB_TAG="branch-$CIRCLE_BRANCH"
+    DOCKERHUB_TAG="branch-$(echo $CIRCLE_BRANCH | sed 's_/_-_g')"
   else
     DOCKERHUB_TAG="latest"
   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
           command: |
             docker load -i workspace-full-vnc.tar
             ./.circleci/build_image.sh dotnet-vnc/Dockerfile gitpod/workspace-dotnet-vnc
+          no_output_timeout: 30m
 
 
 workflows:


### PR DESCRIPTION
It commonly happens that branches in this repository include `/` characters:
- https://github.com/gitpod-io/workspace-images/pull/59#issuecomment-466996060
- https://github.com/gitpod-io/workspace-images/pull/62#issuecomment-469235762

This currently breaks CircleCI builds, because branch names are used in Docker tags, where `/` has a special meaning. To address this, we replace any `/` in branch names with `-` in Docker tags.

Note that this creates a potential tag collision between branches called e.g. `br/anch` and `br-anch`, but I don't consider this a big problem because non-`master` branches are just there for tests.