### PR TITLE
Install Ruby gems in /workspace/.rvm for persistence

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -145,6 +145,7 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \
         && rvm use $RUBY_VERSION --default \
         && rvm rubygems current \
         && gem install bundler --no-document"
+ENV GEM_HOME=/workspace/.rvm
 
 ### Rust ###
 RUN sudo apt-get update \


### PR DESCRIPTION
This puts the default installation directory of Ruby gems inside the `/workspace` volume, thus persisting the result of `gem install <gem>` and `bundle install` over workspace restarts.

As suggested in https://github.com/gitpod-io/gitpod/issues/353#issuecomment-470865743.

Fixes https://spectrum.chat/gitpod/general/snapshots-save-the-state-of-the-workspace-what-does-that-include~2edb3776-dfd4-4224-8322-2b1545f35414.