### PR TITLE
Pre-install Ruby 2.6, 2.5, 2.4

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -135,14 +135,15 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && rm -rf /tmp/*
 
 ### Ruby ###
-ENV RUBY_VERSION=2.6.0
 RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \
     && curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \
-        && rvm install $RUBY_VERSION \
-        && rvm use $RUBY_VERSION --default \
+        && rvm install 2.4 \
+        && rvm install 2.5 \
+        && rvm install 2.6 \
+        && rvm use 2.6 --default \
         && rvm rubygems current \
         && gem install bundler --no-document"
 ENV GEM_HOME=/workspace/.rvm


### PR DESCRIPTION
Should address https://github.com/gitpod-io/gitpod/issues/353 somewhat.

This will not make `rvm install 2.X` persistent, however since `2.4`, `2.5`, and `2.6` will already be pre-installed, you can simply specify this in your `.gitpod.yml`:

```yaml
tasks:
- before: rvm use 2.4
```

This will make sure that your terminals always use Ruby 2.4, even after you restart your workspace.