### PR TITLE
Upgrade to clang-9, install gdb, lld-9, clang-tidy-9

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -9,7 +9,6 @@ RUN yes | unminimize \
         htop \
         jq \
         less \
-        llvm \
         locales \
         man-db \
         nano \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -32,12 +32,15 @@ RUN { echo && echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01
 
 ### C/C++ ###
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && apt-add-repository -yu "deb http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic-6.0 main" \
+    && apt-add-repository -yu "deb http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic main" \
     && apt-get install -yq \
-        clang-format-6.0 \
-        clang-tools-6.0 \
+        clang-format-9 \
+        clang-tidy-9 \
+        clang-tools-9 \
         cmake \
-    && ln -s /usr/bin/clangd-6.0 /usr/bin/clangd \
+        gdb \
+        lld-9 \
+    && ln -s /usr/bin/clangd-9 /usr/bin/clangd \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 ### Apache and Nginx ###

--- a/rethinkdb/Dockerfile
+++ b/rethinkdb/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /tmp/rethinkdb \
  && wget -qOrethinkdb.tgz https://download.rethinkdb.com/dist/rethinkdb-2.3.6.tgz \
  && tar xf rethinkdb.tgz \
  && cd rethinkdb-* \
- && ./configure --allow-fetch CXX=clang++-6.0 \
+ && ./configure --allow-fetch CXX=clang++-9 \
  && make -j`nproc` \
  && sudo make install \
  && sudo rm -rf /tmp/rethinkdb


### PR DESCRIPTION
- The current latest stable version of Clang & co is ~~7~~ 8
- `lld` is much faster than `ld` at linking
- `gdb` is precious for debugging
- `clang-tidy` is a C++ linter that can catch a vast range of dangerous programming errors