### PR TITLE
[python] Use global pip installation target

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -146,8 +146,10 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pyenv install 2.7.15 \
     && pyenv install 3.7.2 \
     && pyenv global 2.7.15 3.7.2 \
-    && pip install --upgrade pip \
-    && pip install virtualenv pipenv \
+    && pip2 install --upgrade pip \
+    && pip2 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit python-language-server[all]==0.25.0 \
+    && pip3 install --upgrade pip \
+    && pip3 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit python-language-server[all]==0.25.0 \
     && rm -rf /tmp/*
 # use global installation location for pip modules
 ENV PIP_TARGET=/workspace/.pip-global

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -143,10 +143,15 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && { echo; \
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> .bashrc \
-    && pyenv install 3.6.6 \
-    && pyenv global 3.6.6 \
-    && pip install virtualenv pipenv python-language-server[all]==0.19.0 \
+    && pyenv install 2.7.15 \
+    && pyenv install 3.7.2 \
+    && pyenv global 2.7.15 3.7.2 \
+    && pip install --upgrade pip \
+    && pip install virtualenv pipenv \
     && rm -rf /tmp/*
+# use global installation location for pip modules
+ENV PIP_TARGET=/workspace/.pip-global
+ENV PYTHONPATH=$PIP_TARGET
 
 ### Ruby ###
 RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \


### PR DESCRIPTION
* `python` is `python2`
* all packages to be installed under `/workspace`
  ⚠️ this introduces a bypass for virtual environments, as those global packages will always be visible.
  
Closes https://github.com/gitpod-io/workspace-images/issues/55