### PR TITLE
[python] Use user modules by default

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -147,8 +147,8 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pip3 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit python-language-server[all]==0.25.0 \
     && rm -rf /tmp/*
 # use global installation location for pip modules
-ENV PIP_TARGET=/workspace/.pip-global
-ENV PYTHONPATH=$PIP_TARGET
+ENV PYTHONUSERBASE=/workspace/.pip-modules \
+    PIP_USER=yes
 
 ### Ruby ###
 RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \


### PR DESCRIPTION
⚠️  This is a breaking change

Unfortunately, a global target installation directory couldn't be used for all regular purposes:
 - to enable scripts I added install options
 - install options disabled wheels and broke setuptools, see https://github.com/gitpod-io/gitpod/issues/460

To fix this, I propose to use `PYTHONUSERBASE` instead. This means also, that due to a different directory layout the existing `/workspace/.pip-global` won't we useable and needs to be replaced by `/workspace/.pip-modules`. User will need to reinstall modules after restarting an old workspace. 

