### PR TITLE
Add new workspace image for projects using RethinkDB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,19 @@ jobs:
             docker load -i workspace-full.tar
             ./.circleci/build_image.sh postgres/Dockerfile gitpod/workspace-postgres
 
+  workspace-rethinkdb:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            docker load -i workspace-full.tar
+            ./.circleci/build_image.sh rethinkdb/Dockerfile gitpod/workspace-rethinkdb
+
 
 workflows:
   version: 2
@@ -106,5 +119,8 @@ workflows:
           requires:
             - workspace-full-vnc
       - workspace-postgres:
+          requires:
+            - workspace-full
+      - workspace-rethinkdb:
           requires:
             - workspace-full

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -113,9 +113,9 @@ ENV GOPATH=/workspace/go \
 ## Place '.gradle' and 'm2-repository' in /workspace because (1) that's a fast volume, (2) it survives workspace-restarts and (3) it can be warmed-up by pre-builds.
 RUN curl -s "https://get.sdkman.io" | bash \
  && bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
-             && yes | sdk install java 8.0.201-oracle \
+             && sdk install java 8.0.212-zulu \
              && sdk install java 11.0.2-open \
-             && sdk default java 8.0.201-oracle \
+             && sdk default java 8.0.212-zulu \
              && sdk install gradle \
              && sdk install maven \
              && mkdir /home/gitpod/.m2 \

--- a/rethinkdb/Dockerfile
+++ b/rethinkdb/Dockerfile
@@ -1,0 +1,24 @@
+FROM gitpod/workspace-full
+
+# Install RethinkDB build dependencies.
+# Source: https://rethinkdb.com/docs/install/ubuntu/#compile-from-source
+RUN sudo apt-get update \
+ && sudo apt-get install -y \
+  protobuf-compiler \
+  libprotobuf-dev \
+  libboost-all-dev \
+  libncurses5-dev \
+  libjemalloc-dev \
+  libssl1.0-dev \
+ && sudo rm -rf /var/lib/apt/lists/*
+
+# Build and install RethinkDB from source.
+RUN mkdir -p /tmp/rethinkdb \
+ && cd /tmp/rethinkdb \
+ && wget -qOrethinkdb.tgz https://download.rethinkdb.com/dist/rethinkdb-2.3.6.tgz \
+ && tar xf rethinkdb.tgz \
+ && cd rethinkdb-* \
+ && ./configure --allow-fetch CXX=clang++-6.0 \
+ && make -j`nproc` \
+ && sudo make install \
+ && sudo rm -rf /tmp/rethinkdb


### PR DESCRIPTION
Needs to be built from source because RethinkDB doesn't provide packages for recent OSes:

http://download.rethinkdb.com/apt/pool/ (last update was on `17-Jul-2017`)