### PR TITLE
[python] bump versions of pyenv installations

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -169,9 +169,9 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && { echo; \
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> .bashrc \
-    && pyenv install 2.7.15 \
-    && pyenv install 3.7.2 \
-    && pyenv global 2.7.15 3.7.2 \
+    && pyenv install 2.7.16 \
+    && pyenv install 3.7.4 \
+    && pyenv global 2.7.16 3.7.4 \
     && pip2 install --upgrade pip \
     && pip2 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit python-language-server[all]==0.25.0 \
     && pip3 install --upgrade pip \


### PR DESCRIPTION
the selection game implemented in the ms-python extension is won by the highest version number, so let's bump it to the latest.