### PR TITLE
[full] Change HomeBrew binary priority from highest → lowest

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -93,9 +93,9 @@ RUN sudo echo "Running 'sudo' for Gitpod: success"
 
 ### Homebrew ###
 RUN mkdir ~/.cache && sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
-ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/:$PATH"
-ENV MANPATH="/home/linuxbrew/.linuxbrew/share/man:$MANPATH"
-ENV INFOPATH="/home/linuxbrew/.linuxbrew/share/info:$INFOPATH"
+ENV PATH="$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/"
+ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"
+ENV INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info"
 
 ### CMake ###
 RUN sudo apt-get remove -y cmake && brew install cmake


### PR DESCRIPTION
Because HomeBrew comes with an old `openssl`, which breaks some downstream images.

Before we installed `brew`:

```
$ openssl version
OpenSSL 1.1.1b  26 Feb 2019
```

With `brew` installed (now):

```
$ openssl version
OpenSSL 1.0.2s  28 May 2019
```

Hopefully, making HomeBrew a good citizen (i.e. moving it to the end of the `PATH`, not overshadowing everything else) will fix that.