### PR TITLE
[full] Upgrade Go from 1.12 → 1.13

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -113,7 +113,7 @@ ENV HOMEBREW_NO_AUTO_UPDATE=1
 LABEL dazzle/layer=lang-go
 LABEL dazzle/test=tests/lang-go.yaml
 USER gitpod
-ENV GO_VERSION=1.12 \
+ENV GO_VERSION=1.13 \
     GOPATH=$HOME/go-packages \
     GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
⚠️ I have not tested this upgrade. It could potentially break Go projects in Gitpod.