### PR TITLE
use avdmanager to preload Android VM

### DIFF
--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -20,4 +20,6 @@ USER gitpod
 
 RUN cd /home/gitpod && wget -qO flutter_sdk.tar.xz https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.0.0-stable.tar.xz \
     && tar -xvf flutter_sdk.tar.xz && rm flutter_sdk.tar.xz && \
-    wget -O - http://dl.google.com/android/android-sdk_r26.1.1-linux.tgz | tar -xvz
+    wget -O - http://dl.google.com/android/android-sdk_r26.1.1-linux.tgz | tar -xvz && \
+    # default to x86 and API Level 28
+    avdmanager create avd -n gitpod -k "system-images;android-28;google_apis;x86" 

--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full-vnc
 
 
-ENV ANDROID_HOME=/home/gitpod/android-sdk-linux \
+ENV ANDROID_HOME=/home/gitpod/android-sdk_r26.1.1-linux \
     FLUTTER_HOME=/home/gitpod/flutter \
     PATH=/usr/lib/dart/bin:$FLUTTER_HOME/bin:$ANDROID_HOME/tools:$PATH
 
@@ -20,6 +20,4 @@ USER gitpod
 
 RUN cd /home/gitpod && wget -qO flutter_sdk.tar.xz https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.0.0-stable.tar.xz \
     && tar -xvf flutter_sdk.tar.xz && rm flutter_sdk.tar.xz && \
-    wget -qO android_studio.zip https://dl.google.com/dl/android/studio/ide-zips/3.3.0.20/android-studio-ide-182.5199772-linux.zip && \
-    unzip android_studio.zip && rm -f android_studio.zip && \
-    wget --output-document=android-sdk.tgz --quiet http://dl.google.com/android/android-sdk_r26.1.1-linux.tgz && tar -xvf android-sdk.tgz && rm android-sdk.tgz;
+    wget -O - http://dl.google.com/android/android-sdk_r26.1.1-linux.tgz | tar -xvz


### PR DESCRIPTION
Unfortunately because of the first Flutter PR's shortcomings I still have to create this PR, which is a follow up.

This PR leverages `avdmanager`, which is a CLI tool to make AVD creation more tolerable on non-interactive environments.

the Gitpod AVD I preloaded comes with Android API Level 28 on x86. Name of the AVD is `gitpod`.