### PR TITLE
[full] Install tk-dev to help Python work with graphical environments

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -172,7 +172,9 @@ ENV PATH=/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH
 
 ### Python ###
 ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
-RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+RUN sudo apt-get update -q \
+    && sudo apt-get install -yq tk-dev \
+    && curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && { echo; \
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> .bashrc \
@@ -183,7 +185,7 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pip2 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
     && pip3 install --upgrade pip \
     && pip3 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
-    && rm -rf /tmp/*
+    && sudo rm -rf /tmp/* /var/lib/apt/lists/*
 # Gitpod will automatically add user site under `/workspace` to persist your packages.
 # ENV PYTHONUSERBASE=/workspace/.pip-modules \
 #    PIP_USER=yes


### PR DESCRIPTION
`tk-dev` needs to be installed _before_ `pyenv` installs Python, thus I install it in `gitpod/workspace-full` and not just `gitpod/workspace-full-vnc`.

See also https://github.com/pyenv/pyenv/issues/94 and https://github.com/pyenv/pyenv/issues/1375.