### PR TITLE
[full] Upgrade .NET SDK from 2.2 → 3.1

### DIFF
--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -2,8 +2,8 @@ FROM gitpod/workspace-full:latest
 
 USER root
 
-RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb && \
+RUN wget -q https://packages.microsoft.com/config/ubuntu/19.04/packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && rm -rf packages-microsoft-prod.deb && \
     add-apt-repository universe && \
-    apt-get update && apt-get -y -o APT::Install-Suggests="true" install dotnet-sdk-2.2 && \
-    apt -y clean;
+    apt-get update && apt-get -y -o APT::Install-Suggests="true" install dotnet-sdk-3.1 && \
+    rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
.NET 3.0 is the currently recommended version on: https://dotnet.microsoft.com/download

Also, .NET 2.2 is in maintenance mode, and support ends on 2019-12-23: https://dotnet.microsoft.com/download/dotnet-core