### PR TITLE
[full] Clear SDKMAN caches to save space. Switch to OpenJDK11. Add tes…

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -162,11 +162,11 @@ LABEL dazzle/test=tests/lang-java.yaml
 USER gitpod
 RUN curl -s "https://get.sdkman.io" | bash \
  && bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
-             && sdk install java 8.0.202-zulufx \
-             && sdk install java 11.0.2-zulufx \
-             && sdk default java 8.0.202-zulufx \
+             && sdk install java 11.0.5-open \
              && sdk install gradle \
              && sdk install maven \
+             && sdk flush archives \
+             && sdk flush temp \
              && mkdir /home/gitpod/.m2 \
              && printf '<settings>\n  <localRepository>/workspace/m2-repository/</localRepository>\n</settings>\n' > /home/gitpod/.m2/settings.xml \
              && echo 'export SDKMAN_DIR=\"/home/gitpod/.sdkman\"' >> /home/gitpod/.bashrc.d/99-java \

--- a/full/tests/lang-java.yaml
+++ b/full/tests/lang-java.yaml
@@ -4,6 +4,12 @@
   assert:
   - status == 0
   - stderr.indexOf("OpenJDK") != -1
+- desc: it should run maven
+  command: [mvn -v]
+  entrypoint: [bash, -i, -c]
+  assert:
+  - status == 0
+  - stdout.indexOf("Apache Maven") != -1
 - desc: it should run sdk
   command: [sdk v]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
Clear SDKMAN caches to save space. Switch to OpenJDK11. Add test for maven.
Using OpenJDK as it is the reference implementation of the JDK.

Cut resultant image size from 9.65gb to 8.45gb.

Fixes: #123 