### PR TITLE
Ensure rubygems doesn't break

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -225,6 +225,9 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \
         && rvm install 2.6 \
         && rvm use 2.6 --default \
         && rvm rubygems current \
+        && gem update --system \
+        && gem update \
+        && gem uninstall rubygems-update \
         && gem install bundler --no-document \
         && gem install solargraph --no-document" \
     && echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*' >> /home/gitpod/.bashrc.d/70-ruby


### PR DESCRIPTION
Due to an update with Bundler, this is needed for ruby projects not to break

cc @jankeromnes for testing