### PR TITLE
[full] Install tk-dev to support some graphical environments in Python

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -195,7 +195,9 @@ LABEL dazzle/layer=lang-python
 LABEL dazzle/test=tests/lang-python.yaml
 USER gitpod
 ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
-RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+RUN sudo apt-get update -q \
+    && sudo apt-get install -yq tk-dev \
+    && curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && { echo; \
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> /home/gitpod/.bashrc.d/60-python \
@@ -206,7 +208,7 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pip2 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
     && pip3 install --upgrade pip \
     && pip3 install virtualenv pipenv pylint rope flake8 mypy autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
-    && rm -rf /tmp/*
+    && sudo rm -rf /tmp/* /var/lib/apt/lists/*
 # Gitpod will automatically add user site under `/workspace` to persist your packages.
 # ENV PYTHONUSERBASE=/workspace/.pip-modules \
 #    PIP_USER=yes


### PR DESCRIPTION
This is a revival of #119:

> `tk-dev` needs to be installed _before_ `pyenv` installs Python, thus I install it in `gitpod/workspace-full` and not just `gitpod/workspace-full-vnc`.
> 
> See also pyenv/pyenv#94 and pyenv/pyenv#1375.

Needed by:
- https://github.com/JesterOrNot/pycalc
- https://community.gitpod.io/t/how-to-install-tk-and-tkinter-gitpod/274

However, as @meysholdt correctly pointed out, this seems to add `libx11` in all workspaces (even non-graphical).

We should check what the impact is of installing `tk-dev` on the `gitpod/workspace-full` image size.