### PR TITLE
Python: add wheel and twine to full by default

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -205,7 +205,7 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pip2 install --upgrade pip \
     && pip2 install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
     && pip3 install --upgrade pip \
-    && pip3 install virtualenv pipenv pylint rope flake8 mypy autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0 \
+    && pip3 install virtualenv pipenv pylint rope flake8 mypy autopep8 pep8 pylama pydocstyle bandit wheel twine notebook python-language-server[all]==0.25.0 \
     && rm -rf /tmp/*
 # Gitpod will automatically add user site under `/workspace` to persist your packages.
 # ENV PYTHONUSERBASE=/workspace/.pip-modules \


### PR DESCRIPTION
Wheel is the official Python packaging support library, and Twine allows you to upload packages to PyPI. 