### PR TITLE
Update Rust installation in workspace-full

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -245,7 +245,7 @@ RUN sudo apt-get update \
 
 RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
     curl -fsSL https://sh.rustup.rs | sh -s -- -y \
-    && .cargo/bin/rustup update stable \
+    && .cargo/bin/rustup toolchain install 1.41 \
     && .cargo/bin/rustup component add rls rust-analysis rust-src \
     && .cargo/bin/rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
     && .cargo/bin/rustup target add x86_64-unknown-linux-musl \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -245,8 +245,8 @@ RUN sudo apt-get update \
 
 RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
     curl -fsSL https://sh.rustup.rs | sh -s -- -y \
-    && .cargo/bin/rustup install 1.39.0 \
-    && .cargo/bin/rustup component add rls-preview rust-analysis rust-src \
+    && .cargo/bin/rustup update stable \
+    && .cargo/bin/rustup component add rls rust-analysis rust-src \
     && .cargo/bin/rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
     && .cargo/bin/rustup target add x86_64-unknown-linux-musl \
     && grep -v -F -x -f /home/gitpod/.profile_orig /home/gitpod/.profile > /home/gitpod/.bashrc.d/80-rust


### PR DESCRIPTION
`rustup install` as an alias for `rustup update` was [deprecated recently](https://users.rust-lang.org/t/notice-deprecation-of-rustup-install-and-rustup-uninstall/35491), and the `rls-preview` feature was [renamed to `rls`](https://github.com/rust-lang/rls/pull/1208) with Rust 2018.