### PR TITLE
Use latest Git instead of the old one provided by Ubuntu

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -23,6 +23,11 @@ RUN yes | unminimize \
 
 ENV LANG=en_US.UTF-8
 
+### Git ###
+RUN add-apt-repository -y ppa:git-core/ppa \
+    && apt-get install -yq git \
+    && rm -rf /var/lib/apt/lists/*
+
 ### Gitpod user ###
 # '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \


### PR DESCRIPTION
This way the users will have the latest version of Git (currently 2.25) instead of the older one provided in the Ubuntu repositories (currently 2.20). 