### PR TITLE
fix(postgres): use $PGDATA

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -9,10 +9,9 @@ RUN sudo apt-get update \
 # Setup PostgreSQL server for user gitpod
 ENV PATH="$PATH:/usr/lib/postgresql/11/bin"
 ENV PGDATA="/home/gitpod/.pg_ctl/data"
-RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/data ~/.pg_ctl/sockets \
- && initdb -D ~/.pg_ctl/data/ \
- && printf "#!/bin/bash\npg_ctl -D ~/.pg_ctl/data/ -l ~/.pg_ctl/log -o \"-k ~/.pg_ctl/sockets\" start\n" > ~/.pg_ctl/bin/pg_start \
- && printf "#!/bin/bash\npg_ctl -D ~/.pg_ctl/data/ -l ~/.pg_ctl/log -o \"-k ~/.pg_ctl/sockets\" stop\n" > ~/.pg_ctl/bin/pg_stop \
+RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets \
+ && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
+ && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
  && chmod +x ~/.pg_ctl/bin/*
 ENV PATH="$PATH:$HOME/.pg_ctl/bin"
 ENV DATABASE_URL="postgresql://gitpod@localhost"
@@ -23,3 +22,4 @@ ENV PGDATABASE="postgres"
 # tasks from a Dockerfile. This workaround checks, on each bashrc eval, if the
 # PostgreSQL server is running, and if not starts it.
 RUN printf "\n# Auto-start PostgreSQL server.\n[[ \$(pg_ctl status | grep PID) ]] || pg_start > /dev/null\n" >> ~/.bashrc
+CMD ["sh", "-c", "mkdir -p $PGDATA && initdb -D $PGDATA", "&&", "sh"]

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -22,4 +22,4 @@ ENV PGDATABASE="postgres"
 # tasks from a Dockerfile. This workaround checks, on each bashrc eval, if the
 # PostgreSQL server is running, and if not starts it.
 RUN printf "\n# Auto-start PostgreSQL server.\n[[ \$(pg_ctl status | grep PID) ]] || pg_start > /dev/null\n" >> ~/.bashrc
-CMD ["sh", "-c", "mkdir -p $PGDATA && initdb -D $PGDATA", "&&", "sh"]
+CMD ["sh", "-c", "'mkdir -p $PGDATA && initdb -D $PGDATA'", "&&", "sh"]

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -8,9 +8,9 @@ RUN sudo apt-get update \
 
 # Setup PostgreSQL server for user gitpod
 ENV PATH="$PATH:/usr/lib/postgresql/11/bin"
-ENV PGDATA="/home/gitpod/.pg_ctl/data"
+ENV PGDATA="/workspace/.pgsql/data"
 RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets \
- && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
+ && printf '#!/bin/bash\n[ ! -d $PGDATA ] && mkdir -p $PGDATA && initdb -D $PGDATA\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
  && chmod +x ~/.pg_ctl/bin/*
 ENV PATH="$PATH:$HOME/.pg_ctl/bin"
@@ -22,4 +22,3 @@ ENV PGDATABASE="postgres"
 # tasks from a Dockerfile. This workaround checks, on each bashrc eval, if the
 # PostgreSQL server is running, and if not starts it.
 RUN printf "\n# Auto-start PostgreSQL server.\n[[ \$(pg_ctl status | grep PID) ]] || pg_start > /dev/null\n" >> ~/.bashrc
-CMD ["sh", "-c", "'mkdir -p $PGDATA && initdb -D $PGDATA'", "&&", "sh"]


### PR DESCRIPTION
There're 2 problems.

1.  $PGDATA is only declared, but not used.
2. User cannot configure $PGDATA (for example, they might want it to be a dir in /workspace, like #171) 

This tries to resolve them. 

Note that this is not tested, so reviewers should do it, if CI is not enough.

P.S. `printf "..."` and `printf '...'` are different. env var would be interpolated with "", but not with ''. For instance, try `printf "$foo"` and `printf '$foo'` in your local machine.