### PR TITLE
[go] Bump Go to 1.14

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -119,7 +119,7 @@ ENV HOMEBREW_NO_AUTO_UPDATE=1
 LABEL dazzle/layer=lang-go
 LABEL dazzle/test=tests/lang-go.yaml
 USER gitpod
-ENV GO_VERSION=1.13 \
+ENV GO_VERSION=1.14 \
     GOPATH=$HOME/go-packages \
     GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
[Go 1.14](https://golang.org/doc/go1.14) was released on the 25h Feb.
This PR bumps Go to 1.14.