### PR TITLE
Update Dockerfile to install both 2.2 and 3.1

### DIFF
--- a/dotnet-vnc/Dockerfile
+++ b/dotnet-vnc/Dockerfile
@@ -6,4 +6,5 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsof
     dpkg -i packages-microsoft-prod.deb && rm -rf packages-microsoft-prod.deb && \
     add-apt-repository universe && \
     apt-get update && apt-get -y -o APT::Install-Suggests="true" install dotnet-sdk-2.2 && \
-    apt -y clean;
+    apt-get update && apt-get -y -o APT::Install-Suggests="true" install dotnet-sdk-3.1 && \
+    rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
I am including both .NET Core 2.2 and .Net Core 3.1 because I have found that some `dotnet tools` are still on .netcore2.2