### PR TITLE
Sync with apt before installing stuffs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
             docker load -i workspace-full.tar
             ./.circleci/build_image.sh full-vnc/Dockerfile gitpod/workspace-full-vnc
             docker save gitpod/workspace-full-vnc -o workspace-full-vnc.tar
+          no_output_timeout: 15m        
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             docker load -i workspace-full.tar
             ./.circleci/build_image.sh full-vnc/Dockerfile gitpod/workspace-full-vnc
             docker save gitpod/workspace-full-vnc -o workspace-full-vnc.tar
-          no_output_timeout: 15m        
+          no_output_timeout: 30m        
       - persist_to_workspace:
           root: .
           paths:

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:disco
 
 ### base ###
-RUN yes | unminimize \
+RUN apt-get update -qq \
     && apt-get install -yq \
         zip \
         unzip \


### PR DESCRIPTION
Why don't we sync package lists before install see 
 [the docker docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get)