### PR TITLE
[full] Don't configure a specific Python PATH in NPM

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -191,8 +191,6 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh |
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \
-        && npm config set python /usr/bin/python --global \
-        && npm config set python /usr/bin/python \
         && npm install -g npm typescript yarn" \
     && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)


### PR DESCRIPTION
It seems we had this configuration line forever, but I'm not sure if it's still useful.

Furthermore, it's now broken, because Ubuntu 20.04 doesn't have a `/usr/bin/python` anymore:

```
gitpod /workspace/spring-petclinic $ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 19.04
Release:        19.04
Codename:       disco

gitpod /workspace/spring-petclinic $ ls -larth /usr/bin/python
lrwxrwxrwx 1 root root 7 Mar  4  2019 /usr/bin/python -> python2
```

vs:

```
gitpod /workspace/workspace-images $ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu Focal Fossa (development branch)
Release:        20.04
Codename:       focal

gitpod /workspace/workspace-images $ ls -larth /usr/bin/python
ls: cannot access '/usr/bin/python': No such file or directory
```