### PR TITLE
[full] Make `python` be Python 3 by default (use `pyenv local 2.7.17` to go back to Python 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
-## unreleased
+## 2020-06-02
 
 - Upgrade all Go tools to get the latest `gopls`, and remove broken `golangci-lint` [gitpod-io/workspace-images#237](https://github.com/gitpod-io/workspace-images/pull/237)
 - Make Python 3 the default `python` version (use `pyenv local 2.7.17` to go back to Python 2) [gitpod-io/workspace-images#214](https://github.com/gitpod-io/workspace-images/pull/214)

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -208,7 +208,7 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pyenv update \
     && pyenv install 2.7.17 \
     && pyenv install 3.8.2 \
-    && pyenv global 2.7.17 3.8.2 \
+    && pyenv global 3.8.2 2.7.17 \
     && python2 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -120,9 +120,9 @@ RUN sudo apt-get remove -y cmake \
 LABEL dazzle/layer=lang-go
 LABEL dazzle/test=tests/lang-go.yaml
 USER gitpod
-ENV GO_VERSION=1.14 \
-    GOPATH=$HOME/go-packages \
-    GOROOT=$HOME/go
+ENV GO_VERSION=1.14
+ENV GOPATH=$HOME/go-packages
+ENV GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar xzs && \
 # install VS Code Go tools from https://github.com/Microsoft/vscode-go/blob/0faec7e5a8a69d71093f08e035d33beb3ded8626/src/goInstallTools.ts#L19-L45
@@ -146,7 +146,6 @@ RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.t
         github.com/cweill/gotests/... \
         github.com/alecthomas/gometalinter \
         honnef.co/go/tools/... \
-        github.com/golangci/golangci-lint/cmd/golangci-lint \
         github.com/mgechev/revive \
         github.com/sourcegraph/go-langserver \
         github.com/go-delve/delve/cmd/dlv \

--- a/full/tests/lang-python.yaml
+++ b/full/tests/lang-python.yaml
@@ -2,16 +2,11 @@
   command: [python, --version]
   assert:
   - status == 0
-  - stderr.indexOf("Python") != -1
+  - stdout.indexOf("Python") != -1
 - desc: it should have pip
   command: [pip, --version]
   assert:
   - status == 0
-- desc: it should default to the correct pip version
-  command: [sh, -c, '[ "$(pip --version)" = "$(pip2 --version)" ] && echo pass']
-  assert:
-  - status == 0
-  - stdout.trim() == "pass"
 - desc: it should have pip3
   command: [pip3, --version]
   assert:
@@ -21,3 +16,8 @@
   assert:
   - status == 0
   - stdout.indexOf("Python 3") != -1
+- desc: it should default to the correct pip version
+  command: [sh, -c, '[ "$(pip --version)" = "$(pip3 --version)" ] && echo pass']
+  assert:
+  - status == 0
+  - stdout.trim() == "pass"

--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -12,7 +12,6 @@ RUN __RR_VERSION__="5.3.0" \
 # https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites#Most_Distros_-_One_Line_Bootstrap_Command
 ENV SHELL=/bin/bash
 RUN sudo apt-get update \
- && pyenv global 3.8.2 2.7.17 \
  && git clone https://github.com/mozilla/gecko-dev/ /tmp/gecko \
  && cd /tmp/gecko \
  && ./mach bootstrap --no-interactive --application-choice=browser \


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/1540