### PR TITLE
[full-vnc] Best practice: Don't stay as "USER root"

### DIFF
--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -1,14 +1,14 @@
 FROM gitpod/workspace-full:latest
 
-USER root
-
 # Install Xvfb, JavaFX-helpers and Openbox window manager
-RUN apt-get update \
-    && apt-get install -yq xvfb x11vnc xterm openjfx libopenjfx-java openbox \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+RUN sudo apt-get update && \
+    sudo apt-get install -yq xvfb x11vnc xterm openjfx libopenjfx-java openbox && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # overwrite this env variable to use a different window manager
 ENV WINDOW_MANAGER="openbox"
+
+USER root
 
 # Install novnc
 RUN git clone https://github.com/novnc/noVNC.git /opt/novnc \
@@ -30,3 +30,5 @@ RUN echo "[ ! -e /tmp/.X0-lock ] && (/usr/bin/start-vnc-session.sh &> /tmp/displ
 RUN notOwnedFile=$(find . -not "(" -user gitpod -and -group gitpod ")" -print -quit) \
     && { [ -z "$notOwnedFile" ] \
         || { echo "Error: not all files/dirs in $HOME are owned by 'gitpod' user & group"; exit 1; } }
+
+USER gitpod

--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -4,10 +4,8 @@ FROM gitpod/workspace-full-vnc
 RUN __RR_VERSION__="5.3.0" \
  && cd /tmp \
  && wget -qO rr.deb https://github.com/mozilla/rr/releases/download/${__RR_VERSION__}/rr-${__RR_VERSION__}-Linux-$(uname -m).deb \
- && dpkg -i rr.deb \
+ && sudo dpkg -i rr.deb \
  && rm -f rr.deb
-
-USER gitpod
 
 # Install Firefox build dependencies.
 # One-line setup command from:


### PR DESCRIPTION
`gitpod/workspace-full-vnc` should be consistent with `gitpod/workspace-full` in that regard.