### PR TITLE
[gecko] Fix image build

### DIFF
--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -15,7 +15,7 @@ RUN sudo apt-get update \
  && pyenv global 3.8.2 2.7.17 \
  && git clone https://github.com/mozilla/gecko-dev/ /tmp/gecko \
  && cd /tmp/gecko \
- && python2.7 python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser \
+ && ./mach bootstrap --no-interactive --application-choice=browser \
  && sudo rm -rf /tmp/gecko /var/lib/apt/lists/*
 
 # Install git-cinnabar.

--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -12,6 +12,7 @@ RUN __RR_VERSION__="5.3.0" \
 # https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites#Most_Distros_-_One_Line_Bootstrap_Command
 ENV SHELL=/bin/bash
 RUN sudo apt-get update \
+ && pyenv global 3.8.2 2.7.17 \
  && git clone https://github.com/mozilla/gecko-dev/ /tmp/gecko \
  && cd /tmp/gecko \
  && python2.7 python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser \


### PR DESCRIPTION
Attempting to fix:

```
[...]
Your version of Mercurial (5.3.1) is sufficiently modern.
Your version of Python (2.7.17) is new enough.
Your version of Rust (1.42.0) is new enough.
Rust supports x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl targets.
Creating global state directory: /home/gitpod/.mozbuild
Traceback (most recent call last):
  File "python/mozboot/bin/bootstrap.py", line 202, in <module>
    sys.exit(main(sys.argv))
  File "python/mozboot/bin/bootstrap.py", line 193, in main
    dasboot.bootstrap()
  File "python/mozboot/mozboot/bootstrap.py", line 469, in bootstrap
    hg=self.instance.which('hg'))
  File "python/mozboot/mozboot/bootstrap.py", line 704, in current_firefox_checkout
    _warn_if_risky_revision(path)
  File "python/mozboot/mozboot/bootstrap.py", line 821, in _warn_if_risky_revision
    from mozversioncontrol import get_repository_object
ImportError: No module named mozversioncontrol
```