### PR TITLE
templates: Add security notice

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Security
-    url: https://www.gitpod.io/contact/
-    about: For **ANYTHING** relevant to security, Do **NOT** make issues here!
+    url: https://www.gitpod.io/security
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Security
+    url: https://www.gitpod.io/contact/
+    about: For **ANYTHING** relevant to security, Do **NOT** make issues here!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Issues
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue please visit https://gitpod.io/security


### PR DESCRIPTION
To avoid people ~~like me~~ being an idiots who make an issues about things they didn't know were serious >.<

This configures the issue UI to point the end-users to proper channel alike IRC and Discord on this example:
![image](https://user-images.githubusercontent.com/11302521/80832502-4f6f9480-8bdc-11ea-8205-1b53448a1119.png)

Signed-off-by: Jacob Hrbek <kreyren@rixotstudio.cz>