### PR TITLE
node: Provide dependencies for canvas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # Reference to configuration - https://github.blog/2017-07-06-introducing-code-owners/
 # Relevant https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# Allow access to original creator of gitpod-1582.sh script
+# Allow access to original creator of gitpod-1520.sh script
 full/scripts/gitpod-1520.sh   @kreyren

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This file is used to grant contributors the ability to make pushes to default branch if the merge request changes the defined paths only
+# Reference to configuration - https://github.blog/2017-07-06-introducing-code-owners/
+# Relevant https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Allow access to original creator of gitpod-1582.sh script
+full/scripts/gitpod-1520.sh   @kreyren

--- a/.github/workspaces/shell.yml
+++ b/.github/workspaces/shell.yml
@@ -1,0 +1,73 @@
+name: Shell
+
+# Relevant to events - https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows
+on:
+  # Trigger the workflow on push to master
+  push:
+    branches:
+      - master
+    paths:
+      - '**.sh'
+  # Trigger the workflow on merge requests
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+    - '**.sh'
+
+jobs:
+  # Linting
+  lint:
+    runs-on: ubuntu-latest
+    container: debian:stable
+    steps:
+      - name: Installing dependencies..
+        run: |
+          # Sync repos
+          # Check for git
+          if ! apt list --installed 2>/dev/null | grep -qP "^git\/stable.*"; then
+            # Check if we can install git
+            if ! apt list | grep -qP "^git\/stable.*"; then
+              apt update
+            elif apt list | grep -qP "^git\/stable.*"; then
+              true
+            else
+              exit 255
+            fi
+            # Install git
+            apt install -y git
+          elif apt list --installed 2>/dev/null | grep -qP "^git\/stable.*"; then
+            true
+          else
+            exit 255
+          fi 
+          # Check for shellcheck
+          if ! apt list --installed 2>/dev/null | grep -qP "^shellcheck\s{1}-.*"; then
+            # Check if we can install shellcheck
+            if ! apt list | grep -qP "^shellcheck\s{1}-.*"; then
+              apt update
+            elif apt list | grep -qP "^shellcheck\s{1}-.*"; then
+              true
+            else
+              exit 255
+            fi
+            # Install shellcheck
+            apt install -y shellcheck
+          elif apt list --installed 2>/dev/null | grep -qP "^shellcheck\s{1}-.*"; then
+            true
+          else
+            exit 255
+          fi 
+      - name: Pulling git dir..
+        uses: actions/checkout@v2
+      - name: Processing files..
+        # Make sure that bash is used
+        shell: bash
+        run: |
+          cd "$GITHUB_WORKSPACE"
+
+          # Process files
+          ## NOTICE: Do not use for loop to avoid pitfall https://mywiki.wooledge.org/BashPitfalls#pf1
+          git --git-dir="$GITHUB_WORKSPACE/.git" ls-files -z -- '*.sh' | while IFS= read -rd '' file; do
+              printf 'linting shell file %s\n' "$file"
+              shellcheck --external-sources --shell=sh "$file"
+          done

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: gitpod/workspace-full-vnc
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: brew install shellcheck

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,5 +1,8 @@
 FROM buildpack-deps:focal
 
+# Used in scripts to point end-users to upstream for issues
+ENV UPSTREAM="https://github.com/gitpod-io/workspace-images"
+
 ### base ###
 RUN yes | unminimize \
     && apt-get install -yq \
@@ -206,8 +209,10 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh |
 # Relevant issue https://github.com/gitpod-io/gitpod/issues/1520
 COPY full/scripts/gitpod-1520.sh /usr/bin/gitpod-1520
 RUN true \
+  && apt-get update \
   && chmod +x /usr/bin/gitpod-1520 \
-  && /usr/bin/gitpod-1520
+  && /usr/bin/gitpod-1520 2>&1 | tee -a /var/log/gitpod-1520 \
+  && rm /usr/bin/gitpod-1520
 COPY --chown=gitpod:gitpod nvm-lazy.sh /home/gitpod/.nvm/nvm-lazy.sh
 ENV PATH=$PATH:/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -192,7 +192,16 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh |
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \
         && npm install -g npm typescript yarn" \
-    && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node
+    && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node \
+    # Relevant issue https://github.com/gitpod-io/gitpod/issues/1520
+    # Upstream configuration https://github.com/Automattic/node-canvas/blob/master/.github/workflows/ci.yaml#L19
+	  && apt-get install -y \
+          build-essential \
+          libcairo2-dev \
+          libpango1.0-dev \
+          libjpeg8-dev \
+          libgif-dev \
+          librsvg2-dev
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
 # Relevant issue https://github.com/gitpod-io/gitpod/issues/1520
 COPY full/scripts/gitpod-1520.sh /usr/bin/gitpod-1520

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -187,12 +187,26 @@ LABEL dazzle/layer=lang-node
 LABEL dazzle/test=tests/lang-node.yaml
 USER gitpod
 ENV NODE_VERSION=12.16.3
+# Relevant issue https://github.com/gitpod-io/gitpod/issues/1520
+## node-nan - required for 'canvas' (npm) to avoid '../../nan/nan.h:176:10: fatal error: nan_callbacks.h: No such file or directory'
+## apt-utils - apt complains about delaying configuration without this
+## node-gyp - required for 'canvas' (npm)
+## libjpeg-dev libgif-dev librsvg2-dev - Required for 'canvas' (npm) to avoid '../src/backend/ImageBackend.cc:74:1: fatal error: opening dependency file ./Release/.deps/Release/obj.target/canvas/src/backend/ImageBackend.o.d.raw: No such file or directory'
 RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | PROFILE=/dev/null bash \
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \
         && npm install -g npm typescript yarn" \
-    && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node
+    && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node \
+    && apt-get install -y \
+        libcairo2-dev \
+        libpango1.0-dev \
+        node-nan \
+        apt-utils \
+        node-gyp \
+        libjpeg-dev \
+        libgif-dev \
+        librsvg2-dev
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
 COPY --chown=gitpod:gitpod nvm-lazy.sh /home/gitpod/.nvm/nvm-lazy.sh
 ENV PATH=$PATH:/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -192,16 +192,13 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh |
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \
         && npm install -g npm typescript yarn" \
-    && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node \
-    # Relevant issue https://github.com/gitpod-io/gitpod/issues/1520 - Requires these dependencies
-    && apt-get install -y \
-        build-essential \
-        libcairo2-dev \
-        libpango1.0-dev \
-        libjpeg8-dev \
-        libgif-dev \
-        librsvg2-dev
+    && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
+# Relevant issue https://github.com/gitpod-io/gitpod/issues/1520
+COPY full/scripts/gitpod-1520.sh /usr/bin/gitpod-1520
+RUN true \
+  && chmod +x /usr/bin/gitpod-1520 \
+  && /usr/bin/gitpod-1520
 COPY --chown=gitpod:gitpod nvm-lazy.sh /home/gitpod/.nvm/nvm-lazy.sh
 ENV PATH=$PATH:/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -187,24 +187,18 @@ LABEL dazzle/layer=lang-node
 LABEL dazzle/test=tests/lang-node.yaml
 USER gitpod
 ENV NODE_VERSION=12.16.3
-# Relevant issue https://github.com/gitpod-io/gitpod/issues/1520
-## node-nan - required for 'canvas' (npm) to avoid '../../nan/nan.h:176:10: fatal error: nan_callbacks.h: No such file or directory'
-## apt-utils - apt complains about delaying configuration without this
-## node-gyp - required for 'canvas' (npm)
-## libjpeg-dev libgif-dev librsvg2-dev - Required for 'canvas' (npm) to avoid '../src/backend/ImageBackend.cc:74:1: fatal error: opening dependency file ./Release/.deps/Release/obj.target/canvas/src/backend/ImageBackend.o.d.raw: No such file or directory'
 RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | PROFILE=/dev/null bash \
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \
         && npm install -g npm typescript yarn" \
     && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node \
+    # Relevant issue https://github.com/gitpod-io/gitpod/issues/1520 - Requires these dependencies
     && apt-get install -y \
+        build-essential \
         libcairo2-dev \
         libpango1.0-dev \
-        node-nan \
-        apt-utils \
-        node-gyp \
-        libjpeg-dev \
+        libjpeg8-dev \
         libgif-dev \
         librsvg2-dev
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)

--- a/full/scripts/gitpod-1520.sh
+++ b/full/scripts/gitpod-1520.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@member.fsf.org> under GPLv3 <https://www.gnu.org/licenses/gpl-3.0.en.html> in 17/05/2020 based on informations from Zach Bjornson <zbbjornson@gmail.com> in https://github.com/Automattic/node-canvas/pull/1582#issuecomment-629837503 for TypeFox company maintaining gitpod <https://gitpod.io> and it's users
+
+###! This is a hotfix for https://github.com/tomas/needle/issues/312 which is on Gitpod causing issue described https://github.com/gitpod-io/gitpod/issues/1520
+
+# Required for docker-build to terminate correctly
+set -e
+
+# Identify script
+myName="script gitpod-1520"
+
+# Output handling
+# FIXME-UPSTREAM: Implement standard (1st wave of krey's refactor)
+einfo() { printf 'INFO: %s\n' "$1" ;}
+ewarn() { printf 'WARNING: %s\n' "$1" ;}
+eerror() { printf 'ERROR: %s\n' "$1" ;}
+die() {
+	case "$1" in
+		0) printf 'SUCCESS: %s\n' "$2" ;;
+		255) printf 'FATAL: Unexpected happend while %s\n' "$2" ;;
+		[1-9] | [1-9][0-9] | 1[0-9][0-9] | 2[0-5][0-5] ) printf 'FATAL: %s\n' "$2" ;;
+		*) printf 'WRONG_ARG(FATAL): %s\n' "$2"; exit 188
+	esac
+
+	exit "$1"
+}
+edebug() {
+	if [ "$DEBUG" = 1 ]; then
+		printf "DEBUG: %s\n" "$1"
+	elif [ "$DEBUG" != 1 ]; then
+		true
+	else
+		die 255 "Processing variable DEBUG with value '$DEBUG' in $myName"
+	fi
+}
+
+# Root escalation - Not expected to run as non-root
+if [ "$(id -u)" != 0 ]; then
+	ewarn "$myName is expected to be invoked as root, but it has been executed from non-root! Trying to use sudo"
+	SUDO="sudo"
+elif [ "$(id -u)" = 0 ]; then
+	unset SUDO
+else
+	die 255 "root escalation in $myName"
+fi
+
+einfo "Invoking $myName to workaround https://github.com/gitpod-io/gitpod/issues/1520"
+
+# FIXME-UPSTREAM: Set for logic (Implemented in 3rd phase of Krey's refactor)
+DISTRO="ubuntu"
+
+# Sanitization for distro used
+case "$DISTRO" in
+	ubuntu) edebug "Expected distribution '$myName' has been parsed in $myName" ;;
+	*) die 1 "Distribution '$DISTRO' is not supported by $myName"
+esac
+
+# Check if curl is available
+if ! command -v curl 1>/dev/null; then
+	case "$DISTRO" in
+		ubuntu)
+			einfo "$myName requires curl to read GitHub API to determine the logic which is not available on this environment, attempting to install it now.."
+			# Do not double-quote, spaces are expected
+			$SUDO apt install -y curl || die 1 "Unable to install curl which is required in $myName"
+		;;
+		*) die 0 "Distribution '$DISTRO' is not affected by https://github.com/gitpod-io/gitpod/issues/1520 to gitpod's knowledge"
+	esac
+elif command -v curl 1>/dev/null; then
+	edebug "Command 'curl' is already available on this environment, no need to process it"
+else
+	die 255 "checking for curl in $myName"
+fi
+
+# Apply workaround for https://github.com/tomas/needle/issues/312 if the issue is not closed
+bugStatus="$(curl https://api.github.com/repos/tomas/needle/issues/312 | grep -o "state.*")"
+case "$bugStatus" in
+	"state\": \"open\",")
+		ewarn "Upstream bug https://github.com/tomas/needle/issues/312 is still open, applying workaround"
+
+		case "$DISTRO" in
+			ubuntu)
+				if [ "$(apt list --installed node-pre-gyp | grep -o node-pre-gyp)" != "node-pre-gyp" ]; then
+					$SUDO apt install -y node-pre-gyp || { eerror "$myName was unable to install package 'node-pre-gyp' which is required to install package 'canvas' using npm to workaround bug https://github.com/gitpod-io/gitpod/issues/1520 which is affected by https://github.com/tomas/needle/issues/312 as suggested in https://github.com/Automattic/node-canvas/pull/1582#issuecomment-629837503" ; exit 0 ;}
+				elif [ "$(apt list --installed node-pre-gyp | grep -o node-pre-gyp)" = "node-pre-gyp" ]; then
+					die 0 "Package 'node-pre-gyp' is already installed, no need to do anything.."
+				else
+					die 255 "resolving package 'node-pre-gyp' in $myName"
+				fi
+			;;
+			*) einfo "Distribution '$DISTRO' is not affected by bug https://github.com/gitpod-io/gitpod/issues/1520, skipping.."
+		esac
+	;;
+	"state\": \"closed\",")
+		ewarn "The issue https://github.com/tomas/needle/issues/312 has been closed which deprecates $myName, please file an issue about this in $UPSTREAM or ideally remove $myName from gitpod's image"
+		exit 0
+	;;
+	*)
+		eerror "Unknown state '$bugStatus' of issue https://github.com/tomas/needle/issues/312 detected, please file a new issue about this in $UPSTREAM"
+esac

--- a/full/scripts/gitpod-1520.sh
+++ b/full/scripts/gitpod-1520.sh
@@ -35,10 +35,12 @@ edebug() {
 }
 
 # Root escalation - Not expected to run as non-root
+edebug "Processing root escalation in $myName"
 if [ "$(id -u)" != 0 ]; then
 	ewarn "$myName is expected to be invoked as root, but it has been executed from non-root! Trying to use sudo"
 	SUDO="sudo"
 elif [ "$(id -u)" = 0 ]; then
+	edebug "$myName has required root permission already, unsetting SUDO variable"
 	unset SUDO
 else
 	die 255 "root escalation in $myName"
@@ -50,12 +52,14 @@ einfo "Invoking $myName to workaround https://github.com/gitpod-io/gitpod/issues
 DISTRO="ubuntu"
 
 # Sanitization for distro used
+edebug "Processing distribution sanitity check"
 case "$DISTRO" in
 	ubuntu) edebug "Expected distribution '$myName' has been parsed in $myName" ;;
 	*) die 1 "Distribution '$DISTRO' is not supported by $myName"
 esac
 
 # Check if curl is available
+edebug "Checking if curl is available"
 if ! command -v curl 1>/dev/null; then
 	case "$DISTRO" in
 		ubuntu)
@@ -79,8 +83,10 @@ case "$bugStatus" in
 
 		case "$DISTRO" in
 			ubuntu)
+				einfo "Attempting to install package 'node-pre-gyp' for $DISTRO in $myName"
 				if [ "$(apt list --installed node-pre-gyp | grep -o node-pre-gyp)" != "node-pre-gyp" ]; then
 					$SUDO apt install -y node-pre-gyp || { eerror "$myName was unable to install package 'node-pre-gyp' which is required to install package 'canvas' using npm to workaround bug https://github.com/gitpod-io/gitpod/issues/1520 which is affected by https://github.com/tomas/needle/issues/312 as suggested in https://github.com/Automattic/node-canvas/pull/1582#issuecomment-629837503" ; exit 0 ;}
+					die 0 "Package 'node-pre-gyp' has been installed on $DISTRO using $myName"
 				elif [ "$(apt list --installed node-pre-gyp | grep -o node-pre-gyp)" = "node-pre-gyp" ]; then
 					die 0 "Package 'node-pre-gyp' is already installed, no need to do anything.."
 				else


### PR DESCRIPTION
~~DO_NOT_MERGE: Merge once the fix is proved to be sufficient in https://github.com/gitpod-io/gitpod/issues/1520~~ Reporter didn't provide an example repository and this works in test environment.

~~**DO_NOT_MERGE**: New discovery https://github.com/Automattic/node-canvas/pull/1582#issuecomment-629827179~~ Resolved

---

I've concluded that these packages `build-essential libcairo2-dev libpango1.0-dev libjpeg8-dev libgif-dev librsvg2-dev` are required for gitpod's ubuntu (Ubuntu 20.04 Focal Fossa (development branch) as of 17/05/2020) to be able to install `canvas` from https://www.npmjs.com/package/canvas using `npm` to avoid failure described in https://github.com/gitpod-io/gitpod/issues/1520
- Also affected by bug https://github.com/tomas/needle/issues/312, see https://github.com/Automattic/node-canvas/pull/1582#issuecomment-629837503

Verify this being a sufficient fix by running proof-of-concept https://gitpod.io/#https://github.com/Kreyren/gitpod-1520 and invoking `npm install` in gitpod's terminal (notice canvas provided in `package.json`)

Fixes: https://github.com/gitpod-io/gitpod/issues/1520

Relevant: https://github.com/Automattic/node-canvas/pull/1582

Signed-off-by: Jacob Hrbek <kreyren@member.fsf.org>