### PR TITLE
[full] Also install 'pip' for system Python 3

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -200,6 +200,9 @@ ENV PATH=$PATH:/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin
 LABEL dazzle/layer=lang-python
 LABEL dazzle/test=tests/lang-python.yaml
 USER gitpod
+RUN sudo apt-get update && \
+    sudo apt-get install -y python3-pip && \
+    sudo rm -rf /var/lib/apt/lists/*
 ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
 RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && { echo; \


### PR DESCRIPTION
As discussed with @AlexTugarev: Installing `pip` also for the system version of Python 3 (i.e. not only in Pyenv's Python 3, which is expected to be the default version) makes it easier to use the system version in Gitpod without too many strange errors / warnings / alerts in the IDE.