### PR TITLE
[full] Uninstall deprecated Apt version of Node.js

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -186,7 +186,8 @@ LABEL dazzle/layer=lang-node
 LABEL dazzle/test=tests/lang-node.yaml
 USER gitpod
 ENV NODE_VERSION=12.18.0
-RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | PROFILE=/dev/null bash \
+RUN sudo apt-get remove -y nodejs nodejs-doc \
+    && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | PROFILE=/dev/null bash \
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \


### PR DESCRIPTION
Even though we use NVM to install the latest stable Node.js, `gitpod/workspace-full` seems to also contain a deprecated Apt version for some reason:

```
$ apt search nodejs
Sorting... Done
Full Text Search... Done
nodejs/now 10.19.0~dfsg-3ubuntu1 amd64 [installed,local]
  evented I/O for V8 javascript - runtime executable

nodejs-doc/now 10.19.0~dfsg-3ubuntu1 all [installed,local]
  API documentation for Node.js, the javascript platform

$ /usr/bin/nodejs --version
v10.19.0
```

We should remove that.