### PR TITLE
[gecko] Uninstall deprecated Apt version of Node.js

### DIFF
--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -15,6 +15,7 @@ RUN sudo apt-get update \
  && git clone https://github.com/mozilla/gecko-dev/ /tmp/gecko \
  && cd /tmp/gecko \
  && ./mach bootstrap --no-interactive --application-choice=browser \
+ && sudo apt-get remove -y nodejs nodejs-doc \
  && sudo rm -rf /tmp/gecko /var/lib/apt/lists/*
 
 # Install git-cinnabar.


### PR DESCRIPTION
The base image `gitpod/workspace-full` already comes with Node.js 12.

However, `./mach bootstrap` seems to `apt-get install nodejs nodejs-doc`, which installs a deprecated Node.js version:

```
$ apt search nodejs
Sorting... Done
Full Text Search... Done
nodejs/now 10.19.0~dfsg-3ubuntu1 amd64 [installed,local]
  evented I/O for V8 javascript - runtime executable

nodejs-doc/now 10.19.0~dfsg-3ubuntu1 all [installed,local]
  API documentation for Node.js, the javascript platform

$ /usr/bin/nodejs --version
v10.19.0
```

This breaks `./mach build`, because it disregards what's in the `PATH` and goes straight to `/usr/bin/nodejs`, and then fails because it wants `> v10.21`.

Removing the deprecated extra Node.js should fix that.