### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/dart/Dockerfile
+++ b/dart/Dockerfile
@@ -8,7 +8,7 @@ USER root
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
     apt-get update && \
-    apt-get -y install  build-essential dart libkrb5-dev gcc make && \
+    apt-get --no-install-recommends install -y  build-essential dart libkrb5-dev gcc make && \
     apt-get clean && \
     apt-get -y autoremove && \
     apt-get -y clean && \

--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -6,7 +6,7 @@ USER gitpod
 # dependencies
 RUN set -ex; \
     sudo apt-get update; \
-    sudo apt-get install -y libglu1-mesa; \
+    sudo apt-get --no-install-recommends install -y libglu1-mesa; \
     sudo rm -rf /var/lib/apt/lists/*
 
 RUN set -ex; \

--- a/flutter/android.Dockerfile
+++ b/flutter/android.Dockerfile
@@ -10,7 +10,7 @@ USER root
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
     apt-get update && \
-    apt-get -y install build-essential dart libkrb5-dev gcc make gradle android-tools-adb android-tools-fastboot && \
+    apt-get --no-install-recommends install -y build-essential dart libkrb5-dev gcc make gradle android-tools-adb android-tools-fastboot && \
     apt-get clean && \
     apt-get -y autoremove && \
     apt-get -y clean && \

--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full:latest
 
 # Install Xvfb, JavaFX-helpers and Openbox window manager
 RUN sudo apt-get update && \
-    sudo apt-get install -yq xvfb x11vnc xterm openjfx libopenjfx-java openbox && \
+    sudo apt-get --no-install-recommends install -yq xvfb x11vnc xterm openjfx libopenjfx-java openbox && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Overwrite this env variable to use a different window manager

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -2,7 +2,7 @@ FROM buildpack-deps:focal
 
 ### base ###
 RUN yes | unminimize \
-    && apt-get install -yq \
+    && apt-get --no-install-recommends install -yq \
         zip \
         unzip \
         bash-completion \
@@ -28,7 +28,7 @@ ENV LANG=en_US.UTF-8
 
 ### Git ###
 RUN add-apt-repository -y ppa:git-core/ppa \
-    && apt-get install -yq git \
+    && apt-get --no-install-recommends install -yq git \
     && rm -rf /var/lib/apt/lists/*
 
 ### Gitpod user ###
@@ -59,7 +59,7 @@ RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-s
     && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
     && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
-    && apt-get install -yq \
+    && apt-get --no-install-recommends install -yq \
         clang \
         clangd \
         clang-format \
@@ -73,7 +73,7 @@ RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-s
 LABEL dazzle/layer=tool-nginx
 LABEL dazzle/test=tests/lang-php.yaml
 USER root
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -yq \
         apache2 \
         nginx \
         nginx-extras \
@@ -205,7 +205,7 @@ LABEL dazzle/layer=lang-python
 LABEL dazzle/test=tests/lang-python.yaml
 USER gitpod
 RUN sudo apt-get update && \
-    sudo apt-get install -y python3-pip && \
+    sudo apt-get --no-install-recommends install -y python3-pip && \
     sudo rm -rf /var/lib/apt/lists/*
 ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
 RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 # Install MySQL
 RUN apt-get update \
- && apt-get install -y mysql-server \
+ && apt-get --no-install-recommends install -y mysql-server \
  && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/* \
  && mkdir /var/run/mysqld \
  && chown -R gitpod:gitpod /etc/mysql /var/run/mysqld /var/log/mysql /var/lib/mysql /var/lib/mysql-files /var/lib/mysql-keyring /var/lib/mysql-upgrade

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -2,7 +2,7 @@ FROM gitpod/workspace-full:latest
 
 # Install PostgreSQL
 RUN sudo apt-get update \
- && sudo apt-get install -y postgresql-12 postgresql-contrib-12 \
+ && sudo apt-get --no-install-recommends install -y postgresql-12 postgresql-contrib-12 \
  && sudo apt-get clean \
  && sudo rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/*
 

--- a/rethinkdb/Dockerfile
+++ b/rethinkdb/Dockerfile
@@ -5,7 +5,7 @@ FROM gitpod/workspace-full
 # Install RethinkDB build dependencies.
 # Source: https://rethinkdb.com/docs/install/ubuntu/#compile-from-source
 RUN sudo apt-get update \
- && sudo apt-get install -y \
+ && sudo apt-get --no-install-recommends install -y \
   protobuf-compiler \
   libprotobuf-dev \
   libboost-all-dev \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>