### PR TITLE
[full] Explicitly install package 'clang' to get the corresponding alias for the suffixed binary (e.g. 'clang-11')

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -56,10 +56,10 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
     && apt-get install -yq \
+        clang \
+        clangd \
         clang-format \
         clang-tidy \
-        # clang-tools \ # breaks the build atm
-        clangd \
         gdb \
         lld \
     && cp /var/lib/dpkg/status /var/lib/apt/dazzle-marks/lang-c.status \


### PR DESCRIPTION
Otherwise, you get `clang-11` in the PATH, but not the convenient `clang` alias.