### PR TITLE
Java 11.0.6.fx-zulu is not available

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -171,7 +171,7 @@ LABEL dazzle/test=tests/lang-java.yaml
 USER gitpod
 RUN curl -fsSL "https://get.sdkman.io" | bash \
  && bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
-             && sdk install java 11.0.6.fx-zulu \
+             && sdk install java 11.0.8.fx-zulu \
              && sdk install gradle \
              && sdk install maven \
              && sdk flush archives \


### PR DESCRIPTION
I face the java version issue at the time of docker image build so I change the version and it install the latest version i.e. Java 11.0.8.fx-zulu
link: https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-fx-jdk11.0.8-linux_x64.tar.gz