### PR TITLE
Publish new images gitpod/workspace-python-tk and gitpod/workspace-tk-python-vnc supporting Tk and Tkinter

### DIFF
--- a/.circleci/build_image.sh
+++ b/.circleci/build_image.sh
@@ -1,16 +1,21 @@
 #!/bin/sh
 set -xe
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 DOCKERFILE IMAGE_NAME"
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 DOCKERFILE IMAGE_NAME [DOCKER_BUILD_ARG]"
   exit 2
 fi
 
 DIR=`dirname $1`
 DOCKERFILE=$1
 IMAGE_NAME=$2
+DOCKER_BUILD_ARG=$3
 
-docker build -t $IMAGE_NAME -f $DOCKERFILE $DIR
+if [[ -z $DOCKER_BUILD_ARG ]]; then
+  docker build -t $IMAGE_NAME -f $DOCKERFILE $DIR
+else
+  docker build -t $IMAGE_NAME -f $DOCKERFILE $DIR --build-arg $DOCKER_BUILD_ARG
+fi
 
 if [[ ! -z $DOCKER_USER ]]; then
   # Log in to Docker Hub.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,41 @@ jobs:
             docker load -i workspace-full.tar
             ./.circleci/build_image.sh wasm/Dockerfile gitpod/workspace-wasm
 
+  workspace-python-tk:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: |
+            ./.circleci/build_image.sh full/Dockerfile gitpod/workspace-python-tk WITH_PYTHON_TK=true
+            docker save gitpod/workspace-python-tk -o workspace-python-tk.tar
+          no_output_timeout: 60m
+      - persist_to_workspace:
+          root: .
+          paths:
+            - workspace-python-tk.tar
+
+  workspace-python-tk-vnc:
+    docker:
+      - image: docker:stable
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            docker load -i workspace-python-tk.tar
+            ./.circleci/build_image.sh full-vnc/Dockerfile gitpod/workspace-python-tk-vnc FROM=gitpod/workspace-python-tk
+            docker save gitpod/workspace-python-tk-vnc -o workspace-python-tk-vnc.tar
+          no_output_timeout: 60m
+      - persist_to_workspace:
+          root: .
+          paths:
+            - workspace-python-tk-vnc.tar
+
 workflows:
   version: 2
   build-and-deploy:
@@ -202,3 +237,7 @@ workflows:
       - workspace-wasm:
           requires:
               - workspace-full
+      - workspace-python-tk
+      - workspace-python-tk-vnc:
+          requires:
+            - workspace-python-tk

--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -1,4 +1,5 @@
-FROM gitpod/workspace-full:latest
+ARG FROM=gitpod/workspace-full:latest
+FROM ${FROM}
 
 # Install Xvfb, JavaFX-helpers and Openbox window manager
 RUN sudo apt-get update && \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -201,8 +201,10 @@ ENV PATH=$PATH:/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin
 ### Python ###
 LABEL dazzle/layer=lang-python
 LABEL dazzle/test=tests/lang-python.yaml
+ARG WITH_PYTHON_TK=false
 USER gitpod
 RUN sudo apt-get update && \
+    if [ "$WITH_PYTHON_TK" = "true" ]; then sudo apt-get install -yq tk-dev; else echo "Not installing tk-dev (use '--build-arg WITH_PYTHON_TK=true' to get it)"; fi && \
     sudo apt-get install -y python3-pip && \
     sudo rm -rf /var/lib/apt/lists/*
 ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH


### PR DESCRIPTION
Requested here (several times): https://community.gitpod.io/t/how-to-install-tk-and-tkinter-gitpod/274

Getting Tk and Tkinter to work with Python in Gitpod is non-trivial, because it needs to be installed _before_ Pyenv, hence the change needs to be in the `gitpod/workspace-full` Dockerfile.

- Previously, users needed to completely fork `gitpod/workspace-full` in order to install `tk-dev`. This wasn't convenient nor future-proof.
- It was also propose to simply install `tk-dev` in `gitpod/workspace-full` and call it a day (https://github.com/gitpod-io/workspace-images/pull/119 and https://github.com/gitpod-io/workspace-images/pull/146). This wasn't ideal either, because it forced `workspace-full` to ship with an entire graphical X stack (quite large and useless for most use cases).

This PR is an attempted compromise: Adding a build argument to `gitpod/workspace-full` that allows installing `tk-dev` optionally. Then use this argument to build two separate images from a single Dockerfile:
- `gitpod/workspace-full` without Tk or X stack (like today)
- `gitpod/workspace-python-tk` with Tk and X stack

Let's see how CircleCI likes that.