### PR TITLE
add docker to workspace-full

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -19,6 +19,7 @@ RUN yes | unminimize \
         vim \
         multitail \
         lsof \
+        ssl-cert \
     && locale-gen en_US.UTF-8 \
     && mkdir /var/lib/apt/dazzle-marks \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
@@ -53,8 +54,9 @@ LABEL dazzle/layer=lang-c
 LABEL dazzle/test=tests/lang-c.yaml
 USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=1
-RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+ENV TRIGGER_REBUILD=3
+RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+    && apt-key add /var/lib/apt/dazzle-marks/llvm.gpg \
     && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
     && apt-get install -yq \
@@ -275,6 +277,25 @@ ENV PATH=$PATH:$HOME/.cargo/bin
 
 RUN bash -lc "cargo install cargo-watch cargo-edit cargo-tree"
 
+### Docker ###
+LABEL dazzle/layer=tool-docker
+LABEL dazzle/test=tests/tool-docker.yaml
+USER root
+# https://docs.docker.com/engine/install/ubuntu/
+RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io slirp4netns docker-compose \
+    && cp /var/lib/dpkg/status /var/lib/apt/dazzle-marks/tool-docker.status \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+# https://github.com/wagoodman/dive
+RUN curl -o /tmp/dive.deb -L https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb \
+    && apt install /tmp/dive.deb \
+    && rm /tmp/dive.deb
+# workaround for https://github.com/gitpod-io/gitpod/issues/2331
+RUN ln -s /usr/bin/runc /usr/sbin/runc
+
 ### Prologue (built across all layers) ###
 LABEL dazzle/layer=dazzle-prologue
 LABEL dazzle/test=tests/prologue.yaml
@@ -286,6 +307,8 @@ RUN cp /var/lib/dpkg/status /tmp/dpkg-status \
     && for i in $(ls /var/lib/apt/dazzle-marks/*.status); do /usr/bin/dazzle-util debian dpkg-status-merge /tmp/dpkg-status $i > /tmp/dpkg-status; done \
     && cp -f /var/lib/dpkg/status /var/lib/dpkg/status-old \
     && cp -f /tmp/dpkg-status /var/lib/dpkg/status
+# merge GPG keys for trusted APT repositories
+RUN for i in $(ls /var/lib/apt/dazzle-marks/*.gpg); do apt-key add "$i"; done
 # copy tests to enable the self-test of this image
 COPY tests /var/lib/dazzle/tests
 

--- a/full/tests/tool-docker.yaml
+++ b/full/tests/tool-docker.yaml
@@ -1,0 +1,13 @@
+- desc: docker should be installed
+  command: [which, docker]
+  assert:
+  - status == 0
+  - stdout.indexOf("/usr/bin/docker") != -1
+- desc: containerd should be installed
+  command: [containerd, config, dump]
+  assert:
+  - status == 0
+- desc: dive should be installed
+  command: [dive, version]
+  assert:
+  - status == 0


### PR DESCRIPTION
This PR adds `dockerd`, `docker` client, `containerd` and [`dive`](https://github.com/wagoodman/dive) to workspace-full.

This is in preparation for fixing https://github.com/gitpod-io/gitpod/issues/52.