### PR TITLE
[full] bump Node.js to 14

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -189,7 +189,7 @@ ENV GRADLE_USER_HOME=/workspace/.gradle/
 LABEL dazzle/layer=lang-node
 LABEL dazzle/test=tests/lang-node.yaml
 USER gitpod
-ENV NODE_VERSION=12.20.0
+ENV NODE_VERSION=14.15.3
 RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | PROFILE=/dev/null bash \
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \


### PR DESCRIPTION
14 is the new LTS version.

You can see https://github.com/nodejs/Release.

