### PR TITLE
Make gitpod/workspace-full image lighter by removing unnecessary/duplicate stuff

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -247,11 +247,7 @@ LABEL dazzle/layer=lang-rust
 LABEL dazzle/test=tests/lang-rust.yaml
 USER gitpod
 RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
-    curl -fsSL https://sh.rustup.rs | sh -s -- -y \
-    && .cargo/bin/rustup toolchain install 1.48.0 \
-    && .cargo/bin/rustup default 1.48.0 \
-    # Save image size by removing now-redudant stable toolchain
-    && .cargo/bin/rustup toolchain uninstall stable \
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.48.0 \
     && .cargo/bin/rustup component add \
         rls \
         rust-analysis \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -213,10 +213,8 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> /home/gitpod/.bashrc.d/60-python \
     && pyenv update \
-    && pyenv install 2.7.18 \
     && pyenv install 3.8.6 \
-    && pyenv global 3.8.6 2.7.18 \
-    && python2 -m pip install --upgrade pip \
+    && pyenv global 3.8.6 \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade \
         setuptools wheel virtualenv pipenv pylint rope flake8 \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -236,7 +236,6 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \
-        && rvm install 2.5.8 \
         && rvm install 2.6.6 \
         && rvm use 2.6.6 --default \
         && rvm rubygems current \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -249,16 +249,6 @@ RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
 LABEL dazzle/layer=lang-rust
 LABEL dazzle/test=tests/lang-rust.yaml
 USER gitpod
-RUN sudo apt-get update \
-    && DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
-        # Enable Rust static binary builds
-        musl \
-        musl-dev \
-        musl-tools \
-    && sudo cp /var/lib/dpkg/status /var/lib/apt/dazzle-marks/lang-rust.status \
-    && sudo apt-get clean \
-    && sudo rm -rf /var/lib/apt/lists/* /tmp/*
-
 RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
     curl -fsSL https://sh.rustup.rs | sh -s -- -y \
     && .cargo/bin/rustup toolchain install 1.48.0 \
@@ -271,7 +261,6 @@ RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
         rust-src \
     && .cargo/bin/rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
     && .cargo/bin/rustup completions bash cargo | sudo tee /etc/bash_completion.d/rustup.cargo-bash-completion > /dev/null \
-    && .cargo/bin/rustup target add x86_64-unknown-linux-musl \
     && grep -v -F -x -f /home/gitpod/.profile_orig /home/gitpod/.profile > /home/gitpod/.bashrc.d/80-rust
 ENV PATH=$PATH:$HOME/.cargo/bin
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -159,9 +159,7 @@ RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.t
         golang.org/x/tools/gopls@v0.5.5 && \
     go get -u -v -d github.com/stamblerre/gocode && \
     go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode && \
-    rm -rf $GOPATH/src && \
-    sudo rm -rf $GOPATH/pkg && \
-    rm -rf /home/gitpod/.cache/go
+    sudo rm -rf $GOPATH/src $GOPATH/pkg /home/gitpod/.cache/go /home/gitpod/.cache/go-build
 # user Go packages
 ENV GOPATH=/workspace/go \
     PATH=/workspace/go/bin:$PATH

--- a/full/tests/lang-rust.yaml
+++ b/full/tests/lang-rust.yaml
@@ -11,15 +11,15 @@
   - status == 0
   - stdout.indexOf("/home/gitpod/.rustup") != -1
   - stdout.indexOf("x86_64-unknown-linux-gnu") != -1
-  - stdout.indexOf("x86_64-unknown-linux-musl") != -1
+  - stdout.indexOf("x86_64-unknown-linux-musl") == -1
 - desc: it should have cargo
   command: [cargo --version]
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-# - desc: it should have matching rustc and cargo versions
-#   command: [cargo --version; rustc --version]
-#   entrypoint: [bash, -i, -c]
-#   assert:
-#   - status == 0
-#   - stdout.split("\n")[0].split(" ")[1] == stdout.split("\n")[1].split(" ")[1]
+- desc: it should have matching rustc and cargo versions
+  command: [cargo --version; rustc --version]
+  entrypoint: [bash, -i, -c]
+  assert:
+  - status == 0
+  - stdout.split("\n")[0].split(" ")[1] == stdout.split("\n")[1].split(" ")[1]


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/workspace-images/issues/124

This PR currently reduces `gitpod/workspace-full` from `7.33 GB` to `6.46 GB`.