### PR TITLE
[full] Update Homebrew + CMake dazzle layer

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -112,6 +112,8 @@ ENV APACHE_DOCROOT_IN_REPO="public" \
 LABEL dazzle/layer=tool-brew
 LABEL dazzle/test=tests/tool-brew.yaml
 USER gitpod
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_BREW_REBUILD=1
 RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/" \
     MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man" \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -112,7 +112,7 @@ ENV APACHE_DOCROOT_IN_REPO="public" \
 LABEL dazzle/layer=tool-brew
 LABEL dazzle/test=tests/tool-brew.yaml
 USER gitpod
-RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH="$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/" \
     MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man" \
     INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info" \


### PR DESCRIPTION
Fixes errors like:

```
$ brew install hub
...
Error: No similarly named formulae found.
Error: No available formula with the name "wayland" (dependency of hub).
It was migrated from linuxbrew/xorg to homebrew/core.
```