### PR TITLE
[full] Invalidate Dazzle layer cache to force-update to latest stable Docker

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -263,6 +263,8 @@ RUN bash -lc "cargo install cargo-watch cargo-edit cargo-tree"
 LABEL dazzle/layer=tool-docker
 LABEL dazzle/test=tests/tool-docker.yaml
 USER root
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_DOCKER_REBUILD=1
 # https://docs.docker.com/engine/install/ubuntu/
 RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
     && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \


### PR DESCRIPTION
Fixes: https://community.gitpod.io/t/docker-20-10-support-on-saas/2499