### PR TITLE
chore : use `--no-cache-dir` flag to `pip`

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -215,8 +215,8 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
     && pyenv update \
     && pyenv install 3.8.8 \
     && pyenv global 3.8.8 \
-    && python3 -m pip install --upgrade pip \
-    && python3 -m pip install --upgrade \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade \
         setuptools wheel virtualenv pipenv pylint rope flake8 \
         mypy autopep8 pep8 pylama pydocstyle bandit notebook \
         twine \

--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -21,7 +21,7 @@ RUN sudo apt-get update \
 # Install moz-phab
 ENV SHELL=/bin/bash
 RUN sudo apt-get update \
- && pip3 install MozPhab \
+ && pip3 install --no-cache-dir MozPhab \
  && echo "PATH=\"\$PATH:$HOME/.local/bin/moz-phab\"" >> $HOME/.bashrc \
  && sudo rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>