### PR TITLE
Fix issues with apache2 and update docker-compose

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,6 +3,8 @@ FROM buildpack-deps:focal
 COPY install-packages /usr/bin
 
 ### base ###
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN yes | unminimize \
     && install-packages \
         zip \

--- a/base/install-packages
+++ b/base/install-packages
@@ -7,6 +7,10 @@ if [ $# = 0 ]; then
   exit 1
 fi
 
+# Set a runlevel to avoid invoke-rc.d warnings
+# http://manpages.ubuntu.com/manpages/focal/man8/runlevel.8.html#environment
+RUNLEVEL=1
+
 DEBIAN_FRONTEND=noninteractive
 
 DAZZLE_MARKS="/var/lib/apt/dazzle-marks/"

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,4 +1,4 @@
-# Dazzle do not supports ARG TRIGGER_REBUILD=1
+# Dazzle do not supports ARG TRIGGER_REBUILD=2
 FROM gitpod/workspace-base:latest
 
 RUN echo "ws full starts"
@@ -209,7 +209,7 @@ RUN bash -lc "cargo install cargo-watch cargo-edit cargo-tree"
 LABEL dazzle/layer=tool-docker
 LABEL dazzle/test=tests/tool-docker.yaml
 USER root
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 # https://docs.docker.com/engine/install/ubuntu/
 RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
     && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,3 +1,4 @@
+# Dazzle do not supports ARG TRIGGER_REBUILD=1
 FROM gitpod/workspace-base:latest
 
 RUN echo "ws full starts"
@@ -23,7 +24,7 @@ RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-s
 LABEL dazzle/layer=tool-nginx
 LABEL dazzle/test=tests/lang-php.yaml
 USER root
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 RUN install-packages \
         apache2 \
         nginx \
@@ -208,6 +209,7 @@ RUN bash -lc "cargo install cargo-watch cargo-edit cargo-tree"
 LABEL dazzle/layer=tool-docker
 LABEL dazzle/test=tests/tool-docker.yaml
 USER root
+ENV TRIGGER_REBUILD=1
 # https://docs.docker.com/engine/install/ubuntu/
 RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
     && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -46,7 +46,7 @@ RUN install-packages \
         php-tokenizer \
         php-xml \
         php-zip \
-    && mkdir -p /var/run/nginx /var/log/apache2 /var/log/nginx/ \
+    && mkdir -p /var/run/nginx \
     && ln -s /etc/apache2/mods-available/rewrite.load /etc/apache2/mods-enabled/rewrite.load \
     && chown -R gitpod:gitpod /etc/apache2 /var/run/apache2 /var/lock/apache2 /var/log/apache2 \
     && chown -R gitpod:gitpod /etc/nginx /var/run/nginx /var/lib/nginx/ /var/log/nginx/
@@ -212,7 +212,11 @@ USER root
 RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
     && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-    && install-packages docker-ce=5:19.03.15~3-0~ubuntu-focal docker-ce-cli=5:19.03.15~3-0~ubuntu-focal containerd.io slirp4netns docker-compose
+    && install-packages docker-ce=5:19.03.15~3-0~ubuntu-focal docker-ce-cli=5:19.03.15~3-0~ubuntu-focal containerd.io slirp4netns
+
+RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/1.28.5/docker-compose-Linux-x86_64 \
+    && chmod +x /usr/local/bin/docker-compose
+
 # https://github.com/wagoodman/dive
 RUN curl -o /tmp/dive.deb -fsSL https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb \
     && apt install /tmp/dive.deb \

--- a/gecko/Dockerfile
+++ b/gecko/Dockerfile
@@ -14,7 +14,7 @@ ENV SHELL=/bin/bash
 RUN sudo apt-get update \
  && git clone --progress --single-branch --depth=1 https://github.com/mozilla/gecko-dev/ /tmp/gecko \
  && cd /tmp/gecko \
- && ./mach bootstrap --no-interactive --application-choice=browser \
+ && ./mach bootstrap --application-choice=browser \
  && sudo apt-get remove -y nodejs nodejs-doc \
  && sudo rm -rf /tmp/gecko /var/lib/apt/lists/*
 


### PR DESCRIPTION
fixes https://github.com/apolopena/gitpod-laravel8-starter/issues/46
fixes https://github.com/gitpod-io/gitpod/issues/3352
fixes #339

Update docker compose to latest stable version. Current version [1.25.0](https://github.com/docker/compose/releases/tag/1.25.0) was released in Nov 2019.

![Screenshot from 2021-03-04 15-19-49](https://user-images.githubusercontent.com/161571/110010728-60f26300-7cfd-11eb-9045-bcc13a90fecb.png)
