### PR TITLE
[full]: add node-gyp as core deps for Node.js

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -141,7 +141,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh |
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \
         && nvm alias default $NODE_VERSION \
-        && npm install -g typescript yarn" \
+        && npm install -g typescript yarn node-gyp" \
     && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
 COPY --chown=gitpod:gitpod nvm-lazy.sh /home/gitpod/.nvm/nvm-lazy.sh


### PR DESCRIPTION
node-gyp is a core part for Node.js call c/cpp modules. https://www.npmjs.com/package/node-gyp (Weekly download with 9 million ATM)