### PR TITLE
Update slirp4netns

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -214,7 +214,10 @@ ENV TRIGGER_REBUILD=2
 RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
     && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-    && install-packages docker-ce=5:19.03.15~3-0~ubuntu-focal docker-ce-cli=5:19.03.15~3-0~ubuntu-focal containerd.io slirp4netns
+    && install-packages docker-ce=5:19.03.15~3-0~ubuntu-focal docker-ce-cli=5:19.03.15~3-0~ubuntu-focal containerd.io
+
+RUN curl -o /usr/bin/slirp4netns -fsSL https://github.com/rootless-containers/slirp4netns/releases/download/v1.1.9/slirp4netns-$(uname -m) \
+    && chmod +x /usr/bin/slirp4netns
 
 RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/1.28.5/docker-compose-Linux-x86_64 \
     && chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
To latest stable version [1.1.9](https://github.com/rootless-containers/slirp4netns/releases/tag/v1.1.9)
Realease [0.4.3](https://github.com/rootless-containers/slirp4netns/releases/tag/v0.4.3) is from Dec 2019

cc @csweichel 