### PR TITLE
[full] Update Composer to v2

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -1,5 +1,6 @@
 # Dazzle do not supports ARG TRIGGER_REBUILD=2
 FROM gitpod/workspace-base:latest
+FROM composer:2 AS composer
 
 RUN echo "ws full starts"
 
@@ -29,7 +30,6 @@ RUN install-packages \
         apache2 \
         nginx \
         nginx-extras \
-        composer \
         php \
         php-all-dev \
         php-bcmath \
@@ -53,6 +53,7 @@ RUN install-packages \
     && chown -R gitpod:gitpod /etc/nginx /var/run/nginx /var/lib/nginx/ /var/log/nginx/
 COPY --chown=gitpod:gitpod apache2/ /etc/apache2/
 COPY --chown=gitpod:gitpod nginx /etc/nginx/
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 ## The directory relative to your git repository that will be served by Apache / Nginx
 ENV APACHE_DOCROOT_IN_REPO="public"


### PR DESCRIPTION
I have updated the way composer was installed, instead of using the version from apt which is still 1.0 I have found that by copying the file from the official composer docker image you can always get the latest stable version of composer put right in place. This fixes issue #339.

Solution found here for reference:
https://github.com/docker-library/docs/tree/master/composer#troubleshooting