### PR TITLE
Use dotnet-install.sh to acquire .NET SDK

### DIFF
--- a/dotnet-lts-vnc/Dockerfile
+++ b/dotnet-lts-vnc/Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full-vnc:latest
+
+USER gitpod
+
+# Install .NET SDK (LTS channel)
+# Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
+RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir /home/gitpod/dotnet
+ENV DOTNET_ROOT=/home/gitpod/dotnet
+ENV PATH=$PATH:/home/gitpod/dotnet

--- a/dotnet-lts/Dockerfile
+++ b/dotnet-lts/Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full:latest
+
+USER gitpod
+
+# Install .NET SDK (LTS channel)
+# Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
+RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --install-dir /home/gitpod/dotnet
+ENV DOTNET_ROOT=/home/gitpod/dotnet
+ENV PATH=$PATH:/home/gitpod/dotnet

--- a/dotnet-vnc/Dockerfile
+++ b/dotnet-vnc/Dockerfile
@@ -2,8 +2,8 @@ FROM gitpod/workspace-full-vnc:latest
 
 USER gitpod
 
-# Install .NET Core 5.0 SDK binaries on Ubuntu 20.04
-# Source: https://dev.to/carlos487/installing-dotnet-core-in-ubuntu-20-04-6jh
-RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://download.visualstudio.microsoft.com/download/pr/a0487784-534a-4912-a4dd-017382083865/be16057043a8f7b6f08c902dc48dd677/dotnet-sdk-5.0.101-linux-x64.tar.gz | tar xz -C /home/gitpod/dotnet
+# Install .NET SDK (Current channel)
+# Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
+RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir /home/gitpod/dotnet
 ENV DOTNET_ROOT=/home/gitpod/dotnet
 ENV PATH=$PATH:/home/gitpod/dotnet

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -2,8 +2,8 @@ FROM gitpod/workspace-full:latest
 
 USER gitpod
 
-# Install .NET Core 5.0 SDK binaries on Ubuntu 20.04
-# Source: https://dev.to/carlos487/installing-dotnet-core-in-ubuntu-20-04-6jh
-RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://download.visualstudio.microsoft.com/download/pr/a0487784-534a-4912-a4dd-017382083865/be16057043a8f7b6f08c902dc48dd677/dotnet-sdk-5.0.101-linux-x64.tar.gz | tar xz -C /home/gitpod/dotnet
+# Install .NET Core 5.0 SDK
+# Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
+RUN mkdir -p /home/gitpod/dotnet && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir /home/gitpod/dotnet
 ENV DOTNET_ROOT=/home/gitpod/dotnet
 ENV PATH=$PATH:/home/gitpod/dotnet

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -2,8 +2,8 @@ FROM gitpod/workspace-full:latest
 
 USER gitpod
 
-# Install .NET Core 5.0 SDK
+# Install .NET SDK (Current channel)
 # Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
-RUN mkdir -p /home/gitpod/dotnet && curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir /home/gitpod/dotnet
+RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir /home/gitpod/dotnet
 ENV DOTNET_ROOT=/home/gitpod/dotnet
 ENV PATH=$PATH:/home/gitpod/dotnet


### PR DESCRIPTION
Changes manual download/unpacking to an install script:

* dotnet-install.sh will keep SDK versions current over time since it installs from a feed
* This defaults to the Current channel (which was already in use) rather than the LTS channel
* Having a separate LTS SDK acquisition will likely require a different workspace (`gitpod/workspace-dotnet-lts` ?)

This was tested here: https://github.com/fslaborg/XPlot/pull/161