### PR TITLE
[full] feat: Add rustfmt component for Rust setup

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -198,6 +198,7 @@ RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
         rls \
         rust-analysis \
         rust-src \
+        rustfmt \
     && .cargo/bin/rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
     && .cargo/bin/rustup completions bash cargo | sudo tee /etc/bash_completion.d/rustup.cargo-bash-completion > /dev/null \
     && grep -v -F -x -f /home/gitpod/.profile_orig /home/gitpod/.profile > /home/gitpod/.bashrc.d/80-rust


### PR DESCRIPTION
While working with rust over Gitpod you would always notice that the formatter is missing for `.rs` files(aka Rust project files) and you have to manually install it every-time. Although if I'm not wrong then Gitpod is meant to be bare-bones when it comes to ready to use workspaces ;) And since the additional formatter is being installed for [clang](https://github.com/gitpod-io/workspace-images/blob/409e1707b3cbe6752a894893cd6354fc13d7b8f5/full/Dockerfile#L18) and [golang](https://github.com/gitpod-io/workspace-images/blob/409e1707b3cbe6752a894893cd6354fc13d7b8f5/full/Dockerfile#L100) as well, why not for rustlang :smile: ?

Anyway, `rustfmt` comes by default unless you specify [minimal](https://github.com/gitpod-io/workspace-images/blob/409e1707b3cbe6752a894893cd6354fc13d7b8f5/full/Dockerfile#L196) profile for installing RustLang thru rustup.sh but that's totally fine, we can just install the formatter separately as done for clang and golang in the `full` workspace-image.

Thanks.