### PR TITLE
Update Ruby to 2.7.3 in full image

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -180,8 +180,9 @@ RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \
-        && rvm install 2.6.6 \
-        && rvm use 2.6.6 --default \
+        && rvm install 3.0.1 \
+        && rvm install 2.6.7 \
+        && rvm use 2.6.7 --default \
         && rvm rubygems current \
         && gem install bundler --no-document \
         && gem install solargraph --no-document" \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -180,9 +180,8 @@ RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \
-        && rvm install 3.0.1 \
-        && rvm install 2.6.7 \
-        && rvm use 2.6.7 --default \
+        && rvm install 2.7.3 \
+        && rvm use 2.7.3 --default \
         && rvm rubygems current \
         && gem install bundler --no-document \
         && gem install solargraph --no-document" \


### PR DESCRIPTION
While #213 upgraded Ruby to 2.7 once, but reverted it in e9281a207c4c6b4c7df2e91e9ec81f36ed0652ae, Ruby 2.6.6 has some security vulnerabilities described in https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/.
As Ruby 3.0.1 is also available, we can add it into the full image.