### PR TITLE
[full] Force Dazzle rebuild of Node.js layer to include newest nvm-lazy.sh

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -137,6 +137,7 @@ LABEL dazzle/layer=lang-node
 LABEL dazzle/test=tests/lang-node.yaml
 USER gitpod
 ENV NODE_VERSION=14.17.0
+ENV TRIGGER_REBUILD=1
 RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | PROFILE=/dev/null bash \
     && bash -c ". .nvm/nvm.sh \
         && nvm install $NODE_VERSION \


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/gitpod/issues/4445

**Explanation**: It looks like a bad version of `~/.nvm/nvm-lazy.sh` got stuck in a Dazzle cache during the development of https://github.com/gitpod-io/workspace-images/pull/411, and then was never updated with the fixes because the Node.js Dazzle layer wasn't modified again in subsequent commits.

It seems a bit wild to me that Dazzle re-uses WIP caches from Pull Requests when deploying to production.