### PR TITLE
[full] Add golangci-lint

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -108,8 +108,8 @@ RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.t
         github.com/godoctor/godoctor && \
     GO111MODULE=on go get -v \
         golang.org/x/tools/gopls@v0.6.11 && \
-    sudo rm -rf $GOPATH/src $GOPATH/pkg /home/gitpod/.cache/go /home/gitpod/.cache/go-build && \
-    	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1 && \
+    sudo rm -rf $GOPATH/src $GOPATH/pkg /home/gitpod/.cache/go /home/gitpod/.cache/go-build
 # user Go packages
 ENV GOPATH=/workspace/go \
     PATH=/workspace/go/bin:$PATH

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -81,34 +81,19 @@ ENV GOPATH=$HOME/go-packages
 ENV GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar xzs && \
-# install VS Code Go tools from https://github.com/Microsoft/vscode-go/blob/0faec7e5a8a69d71093f08e035d33beb3ded8626/src/goInstallTools.ts#L19-L45
+# install VS Code Go tools for use with gopls as per https://github.com/golang/vscode-go/blob/master/docs/tools.md
+# also https://github.com/golang/vscode-go/blob/27bbf42a1523cadb19fad21e0f9d7c316b625684/src/goTools.ts#L139
     go get -v \
-        github.com/mdempsky/gocode \
         github.com/uudashr/gopkgs/cmd/gopkgs@v2 \
         github.com/ramya-rao-a/go-outline \
-        github.com/acroca/go-symbols \
-        golang.org/x/tools/cmd/guru \
-        golang.org/x/tools/cmd/gorename \
+        github.com/cweill/gotests/gotests \
         github.com/fatih/gomodifytags \
-        github.com/haya14busa/goplay/cmd/goplay \
         github.com/josharian/impl \
-        github.com/tylerb/gotype-live \
-        github.com/rogpeppe/godef \
-        github.com/zmb3/gogetdoc \
-        golang.org/x/tools/cmd/goimports \
-        github.com/sqs/goreturns \
-        winterdrache.de/goformat/goformat \
-        golang.org/x/lint/golint \
-        github.com/cweill/gotests/... \
-        honnef.co/go/tools/... \
-        github.com/mgechev/revive \
-        github.com/sourcegraph/go-langserver \
+        github.com/haya14busa/goplay/cmd/goplay \
         github.com/go-delve/delve/cmd/dlv \
-        github.com/davidrjenni/reftools/cmd/fillstruct \
-        github.com/godoctor/godoctor && \
+        github.com/golangci/golangci-lint/cmd/golangci-lint && \
     GO111MODULE=on go get -v \
-        golang.org/x/tools/gopls@v0.6.11 && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1 && \
+        golang.org/x/tools/gopls@v0.7 && \
     sudo rm -rf $GOPATH/src $GOPATH/pkg /home/gitpod/.cache/go /home/gitpod/.cache/go-build
 # user Go packages
 ENV GOPATH=/workspace/go \

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -108,7 +108,8 @@ RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.t
         github.com/godoctor/godoctor && \
     GO111MODULE=on go get -v \
         golang.org/x/tools/gopls@v0.6.11 && \
-    sudo rm -rf $GOPATH/src $GOPATH/pkg /home/gitpod/.cache/go /home/gitpod/.cache/go-build
+    sudo rm -rf $GOPATH/src $GOPATH/pkg /home/gitpod/.cache/go /home/gitpod/.cache/go-build && \
+    	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1
 # user Go packages
 ENV GOPATH=/workspace/go \
     PATH=/workspace/go/bin:$PATH

--- a/full/tests/lang-go.yaml
+++ b/full/tests/lang-go.yaml
@@ -7,12 +7,12 @@
   command: [gotests, "-h"]
   assert:
     - status == 0
-    - stdout.indexOf("gotests") != -1
+    - stderr.indexOf("gotests") != -1
 - desc: it should have gopkgs
   command: [gopkgs]
   assert:
     - status == 0
-    - stdout.indexOf("gopkgs") != -1
+    - stderr.indexOf("gopkgs") != -1
 - desc: it should have gopls
   command: [gopls, version]
   assert:

--- a/full/tests/lang-go.yaml
+++ b/full/tests/lang-go.yaml
@@ -9,7 +9,7 @@
     - status == 0
     - stderr.indexOf("gotests") != -1
 - desc: it should have gopkgs
-  command: [gopkgs]
+  command: [gopkgs, "-h"]
   assert:
     - status == 0
     - stderr.indexOf("gopkgs") != -1
@@ -24,7 +24,7 @@
     - status == 0
     - stdout.indexOf("Delve") != -1
 - desc: it should have golangci-lint
-  command: ["golangci-lint", "version"]
+  command: ["golangci-lint", version]
   assert:
     - status == 0
     - stdout.indexOf("golangci-lint") != -1

--- a/full/tests/lang-go.yaml
+++ b/full/tests/lang-go.yaml
@@ -1,18 +1,30 @@
 - desc: it should run
   command: [go, version]
   assert:
-  - stdout.indexOf("go version") != -1
-  - status == 0
-- desc: it should have gocode
-  command: [gocode]
+    - status == 0
+    - stdout.indexOf("go version") != -1
+- desc: it should have gotests
+  command: [gotests, "-h"]
   assert:
-  - status == 0
+    - status == 0
+    - stdout.indexOf("gotests") != -1
 - desc: it should have gopkgs
   command: [gopkgs]
   assert:
-  - status == 0
+    - status == 0
+    - stdout.indexOf("gopkgs") != -1
 - desc: it should have gopls
   command: [gopls, version]
   assert:
-  - status == 0
-  - stdout.indexOf("gopls") != -1
+    - status == 0
+    - stdout.indexOf("gopls") != -1
+- desc: it should have Delve
+  command: [dlv, version]
+  assert:
+    - status == 0
+    - stdout.indexOf("Delve") != -1
+- desc: it should have golangci-lint
+  command: ["golangci-lint", "version"]
+  assert:
+    - status == 0
+    - stdout.indexOf("golangci-lint") != -1


### PR DESCRIPTION
golangci-lint is the defacto go linter. Installing it in full will make it available for everyone to use. 
Worth noting that VSCode will fail silently if your config specifies golangci and it isn't present :-(