### PR TITLE
full/Dockerfile: Install ripgrep

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -o /var/lib/apt/dazzle-marks/llvm.gpg -fsSL https://apt.llvm.org/llvm-s
         clang-format \
         clang-tidy \
         gdb \
-        lld
+        lld ripgrep
 
 ### Apache, PHP and Nginx ###
 LABEL dazzle/layer=tool-nginx


### PR DESCRIPTION
Ripgrep is a very important and easy to use/handy for searching strings. 
Installing it everytime is PITA.