### PR TITLE
base/dockerfile: Install ripgrep

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,6 +18,7 @@ RUN yes | unminimize \
         locales \
         man-db \
         nano \
+        ripgrep \
         software-properties-common \
         sudo \
         time \


### PR DESCRIPTION
Ripgrep is a handy tool for devs to perform search operations at blazingly fast speeds and pretty less memory consumption.