### PR TITLE
Update full-vnc image to better support JavaFX dev

### DIFF
--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -9,6 +9,10 @@ ENV WINDOW_MANAGER="openbox"
 
 USER root
 
+# Make JavaFX display windows with visible content 
+RUN echo export JAVA_TOOL_OPTIONS=\"\$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\" >> /home/gitpod/.bashrc
+
+
 # Change the default number of virtual desktops from 4 to 1 (footgun)
 RUN sed -ri "s/<number>4<\/number>/<number>1<\/number>/" /etc/xdg/openbox/rc.xml
 

--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -10,10 +10,7 @@ ENV WINDOW_MANAGER="openbox"
 USER root
 
 # Make JavaFX display windows with visible content
-RUN echo >> /home/gitpod/.bashrc
-RUN echo '# Make JavaFX display windows with visible content' >> /home/gitpod/.bashrc
-RUN echo export JAVA_TOOL_OPTIONS=\"\$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\" >> /home/gitpod/.bashrc
-
+RUN echo -e "\n"'# Make JavaFX display windows with visible content'"\n"JAVA_TOOL_OPTIONS=\"\$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\""\n" >> /home/gitpod/.bashrc
 
 # Change the default number of virtual desktops from 4 to 1 (footgun)
 RUN sed -ri "s/<number>4<\/number>/<number>1<\/number>/" /etc/xdg/openbox/rc.xml

--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -9,7 +9,9 @@ ENV WINDOW_MANAGER="openbox"
 
 USER root
 
-# Make JavaFX display windows with visible content 
+# Make JavaFX display windows with visible content
+RUN echo >> /home/gitpod/.bashrc
+RUN echo '# Make JavaFX display windows with visible content' >> /home/gitpod/.bashrc
 RUN echo export JAVA_TOOL_OPTIONS=\"\$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\" >> /home/gitpod/.bashrc
 
 

--- a/full-vnc/Dockerfile
+++ b/full-vnc/Dockerfile
@@ -10,7 +10,7 @@ ENV WINDOW_MANAGER="openbox"
 USER root
 
 # Make JavaFX display windows with visible content
-RUN echo -e "\n"'# Make JavaFX display windows with visible content'"\n"JAVA_TOOL_OPTIONS=\"\$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\""\n" >> /home/gitpod/.bashrc
+RUN echo "\n"'# Make JavaFX display windows with visible content'"\n"JAVA_TOOL_OPTIONS=\"\$JAVA_TOOL_OPTIONS -Dsun.java2d.xrender=false\""\n" >> /home/gitpod/.bashrc
 
 # Change the default number of virtual desktops from 4 to 1 (footgun)
 RUN sed -ri "s/<number>4<\/number>/<number>1<\/number>/" /etc/xdg/openbox/rc.xml


### PR DESCRIPTION
When developing JavaFX (and probably also AWT) apps, the contents of them is not visible. This change makes java processes start with an option that fixes (or does not provoke, maybe is a better description) the problem.

See https://github.com/gitpod-io/gitpod/issues/1004 for a discussion about the problem.