### PR TITLE
[full] Force Homebrew layer rebuild

### DIFF
--- a/.github/ISSUE_TEMPLATE/.config.yml
+++ b/.github/ISSUE_TEMPLATE/.config.yml
@@ -1,4 +1,0 @@
-contact_links:
-  - name: Forum
-    url: https://community.gitpod.io/
-    about: For complicated questions and forum relevant topics

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,7 @@
 contact_links:
+  - name: Forum
+    url: https://community.gitpod.io/
+    about: For complicated questions and forum relevant topics
   - name: Security
     url: https://www.gitpod.io/security
     about: Please report security vulnerabilities here.

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -63,7 +63,7 @@ LABEL dazzle/layer=tool-brew
 LABEL dazzle/test=tests/tool-brew.yaml
 USER gitpod
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_BREW_REBUILD=2
+ENV TRIGGER_BREW_REBUILD=3
 RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH=$PATH:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/
 ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"


### PR DESCRIPTION
An attempt to work around https://github.com/gitpod-io/gitpod/issues/5280

## Description
<!-- Describe your changes in detail -->
Update HomeBrew by invalidating the Dazzle layer cache with a simple change.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/5280

## How to test
<!-- Provide steps to test this PR -->

1. Use the Docker image of this PR in your repository: `gitpod/workspace-full:branch-jx-update-brew-1`
2. Confirm that commands like `brew update` and `brew install stripe/stripe-cli/stripe` work as expected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update HomeBrew in gitpod/workspace-full
```
