### PR TITLE
fix(base): upgrade to latest dependencies when building

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:focal
 
-COPY install-packages /usr/bin
+COPY install-packages upgrade-packages /usr/bin/
 
 ### base ###
 ARG DEBIAN_FRONTEND=noninteractive
@@ -34,8 +34,7 @@ RUN yes | unminimize \
 ENV LANG=en_US.UTF-8
 
 ### Update and upgrade the base image ###
-RUN apt-get update \
-    && apt-get -y upgrade
+RUN upgrade-packages
 
 ### Git ###
 RUN add-apt-repository -y ppa:git-core/ppa \

--- a/base/upgrade-packages
+++ b/base/upgrade-packages
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errexit
+
+# Block users from running this unless they're root.
+if [[ $EUID != 0 ]]; then
+  echo >&2 "Run this script again as root to upgrade packages."
+  exit 1
+fi
+
+# Set a runlevel to avoid invoke-rc.d warnings
+# http://manpages.ubuntu.com/manpages/focal/man8/runlevel.8.html#environment
+# shellcheck disable=SC2034
+RUNLEVEL=1
+
+# shellcheck disable=SC2034
+DEBIAN_FRONTEND=noninteractive
+
+DAZZLE_MARKS="/var/lib/apt/dazzle-marks/"
+TIMESTAMP=$(date +%s)
+
+if [ ! -d "${DAZZLE_MARKS}" ]; then
+  mkdir -p "${DAZZLE_MARKS}"
+fi
+
+apt-get update
+apt-get upgrade -yq --no-install-recommends
+
+cp /var/lib/dpkg/status "${DAZZLE_MARKS}/${TIMESTAMP}.status"
+
+apt-get clean -y
+
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /tmp/* \
+   /var/tmp/*


### PR DESCRIPTION
## Description

workspace-images/base did not update the base focal image

## Related Issue(s)

Fixes https://github.com/gitpod-io/workspace-images/issues/528 and https://github.com/gitpod-io/gitpod/issues/5984

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
* Resolves letsencrypt root certificate expiry

```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
