### PR TITLE
feat(workspace-full): install tailscale

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -227,6 +227,18 @@ RUN curl -o /tmp/dive.deb -fsSL https://github.com/wagoodman/dive/releases/downl
     && apt install /tmp/dive.deb \
     && rm /tmp/dive.deb
 
+### Install Tailscale ###
+LABEL dazzle/layer=tool-tailscale
+LABEL dazzle/test=tests/tool-tailscale.yaml
+USER root
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_REBUILD=1
+
+RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key add - \
+    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
+    && apt-get update \
+    && apt-get install -y tailscale
+
 ### Prologue (built across all layers) ###
 LABEL dazzle/layer=dazzle-prologue
 LABEL dazzle/test=tests/prologue.yaml

--- a/full/tests/tool-tailscale.yaml
+++ b/full/tests/tool-tailscale.yaml
@@ -1,0 +1,5 @@
+- desc: tailscale should be installed
+  command: [which, tailscale]
+  assert:
+  - status == 0
+  - stdout.indexOf("/usr/bin/tailscale") != -1


### PR DESCRIPTION
## Description

- Initial commit that adds tailscale to the workspace-full image.

## Related Issue(s)

Related to https://github.com/gitpod-io/gitpod/issues/3258

## How to test

Review https://github.com/gitpod-io/gitpod/issues/3258#issuecomment-950248225 and https://github.com/DentonGentry/gitpod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- The workspace full image now has tailscale installed by default.
```
