### PR TITLE
Revert "Autofix: upgrade-rustup-toolchain (#532)"

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -186,7 +186,7 @@ LABEL dazzle/layer=lang-rust
 LABEL dazzle/test=tests/lang-rust.yaml
 USER gitpod
 RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
-    curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.56.0 \
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.55.0 \
     && .cargo/bin/rustup component add \
         rls \
         rust-analysis \


### PR DESCRIPTION
This reverts commit 878bb5aede03c764ec2d1eeef54030614ffea0f3.

## Description

Backing out due to community reports at https://www.reddit.com/r/rust/comments/qdivb5/156_compile_time_is_through_the_roof/

