### PR TITLE
[base] apply security updates and resolve lets encrypt expiration (#540)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:focal
 
-COPY install-packages /usr/bin
+COPY install-packages upgrade-packages /usr/bin/
 
 ### base ###
 ARG DEBIAN_FRONTEND=noninteractive
@@ -34,8 +34,7 @@ RUN yes | unminimize \
 ENV LANG=en_US.UTF-8
 
 ### Update and upgrade the base image ###
-RUN apt-get update \
-    && apt-get -y upgrade
+RUN upgrade-packages
 
 ### Git ###
 RUN add-apt-repository -y ppa:git-core/ppa \

--- a/base/upgrade-packages
+++ b/base/upgrade-packages
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errexit
+
+# Block users from running this unless they're root.
+if [[ $EUID != 0 ]]; then
+  echo >&2 "Run this script again as root to upgrade packages."
+  exit 1
+fi
+
+# Set a runlevel to avoid invoke-rc.d warnings
+# http://manpages.ubuntu.com/manpages/focal/man8/runlevel.8.html#environment
+# shellcheck disable=SC2034
+RUNLEVEL=1
+
+# shellcheck disable=SC2034
+DEBIAN_FRONTEND=noninteractive
+
+DAZZLE_MARKS="/var/lib/apt/dazzle-marks/"
+TIMESTAMP=$(date +%s)
+
+if [ ! -d "${DAZZLE_MARKS}" ]; then
+  mkdir -p "${DAZZLE_MARKS}"
+fi
+
+apt-get update
+apt-get upgrade -yq --no-install-recommends
+
+cp /var/lib/dpkg/status "${DAZZLE_MARKS}/${TIMESTAMP}.status"
+
+apt-get clean -y
+
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /tmp/* \
+   /var/tmp/*


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR will add an `upgrade-packages` script to the base workspace image to ensure system packages are up-to-date while leaving no junk, similiar to `install-packages` script.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

See https://github.com/gitpod-io/workspace-images/pull/535#discussion_r736333073 for context.

## How to test
<!-- Provide steps to test this PR -->

Run `./base/upgrade-packages` as root, since I designed the script to bail out if run by regular users.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- Security updates in the base image are now applied.
- Resolves letsencrypt root certificate expiry.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
