### PR TITLE
[full] Upgrade to Ruby 2.7.4

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -169,8 +169,8 @@ RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \
-        && rvm install 2.7.3 \
-        && rvm use 2.7.3 --default \
+        && rvm install 2.7.4 \
+        && rvm use 2.7.4 --default \
         && rvm rubygems current \
         && gem install bundler --no-document \
         && gem install solargraph --no-document" \


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Upgrade Ruby from 2.7.3 to 2.7.4.

## Related Issue(s)
n/a

cf. #392

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
- Bump Ruby to 2.7.4
```


## Documentation
No

## Refs.
- #392
