### PR TITLE
feat(workspace-full): nix package manager

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -237,6 +237,35 @@ RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key
     && apt-get update \
     && apt-get install -y tailscale
 
+### Install nix ###
+LABEL dazzle/layer=tool-nix
+LABEL dazzle/test=tests/tool-nix.yaml
+ENV NIX_VERSION=2.3.14
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_REBUILD=1
+
+USER root
+RUN addgroup --system nixbld \
+  && adduser gitpod nixbld \
+  && for i in $(seq 1 30); do useradd -ms /bin/bash nixbld$i && adduser nixbld$i nixbld; done \
+  && mkdir -m 0755 /nix && chown gitpod /nix \
+  && mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
+
+# Install Nix
+USER gitpod
+ENV USER gitpod
+WORKDIR /home/gitpod
+
+RUN curl https://nixos.org/releases/nix/nix-$NIX_VERSION/install | sh
+
+RUN echo '. /home/gitpod/.nix-profile/etc/profile.d/nix.sh' >> /home/gitpod/.bashrc
+RUN mkdir -p /home/gitpod/.config/nixpkgs && echo '{ allowUnfree = true; }' >> /home/gitpod/.config/nixpkgs/config.nix
+
+# Install cachix
+RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
+  && nix-env -iA cachix -f https://cachix.org/api/v1/install \
+  && cachix use cachix
+
 ### Prologue (built across all layers) ###
 LABEL dazzle/layer=dazzle-prologue
 LABEL dazzle/test=tests/prologue.yaml

--- a/full/tests/tool-nix.yaml
+++ b/full/tests/tool-nix.yaml
@@ -1,0 +1,5 @@
+- desc: nix-env should be installed
+  command: [which, /home/gitpod/.nix-profile/bin/nix-env]
+  assert:
+  - status == 0
+  - stdout.indexOf("/home/gitpod/.nix-profile/bin/nix-env") != -1

--- a/full/tests/tool-nix.yaml
+++ b/full/tests/tool-nix.yaml
@@ -3,3 +3,8 @@
   assert:
   - status == 0
   - stdout.indexOf("/home/gitpod/.nix-profile/bin/nix-env") != -1
+- desc: it should run nix-shell
+  command: [nix-shell --version]
+  entrypoint: [bash, -i, -c]
+  assert:
+  - status == 0


### PR DESCRIPTION
## Description

Adds the nix package manager to the workspace-full image for the people, like myself, who prefer nix over homebrew.

## Related Issue(s)

Fixes https://github.com/gitpod-io/workspace-images/pull/482
Fixes https://github.com/gitpod-io/workspace-images/issues/477

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- The nix package manger is now available in workspace-full.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
