### PR TITLE
feat(workspace-full): include .NET by default

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -203,6 +203,17 @@ RUN sudo mkdir -p $CARGO_HOME \
 
 RUN bash -lc "cargo install cargo-watch cargo-edit cargo-tree cargo-workspaces"
 
+### .NET SDK (Current channel) ###
+LABEL dazzle/layer=lang-dotnet
+LABEL dazzle/test=tests/lang-dotnet.yaml
+ENV TRIGGER_REBUILD=1
+
+# Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
+USER gitpod
+RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir /home/gitpod/dotnet
+ENV DOTNET_ROOT=/home/gitpod/dotnet
+ENV PATH=$PATH:/home/gitpod/dotnet
+
 ### Docker ###
 LABEL dazzle/layer=tool-docker
 LABEL dazzle/test=tests/tool-docker.yaml

--- a/full/tests/lang-dotnet.yaml
+++ b/full/tests/lang-dotnet.yaml
@@ -2,4 +2,3 @@
   command: [dotnet, version]
   assert:
     - status == 0
-    - stdout.indexOf("dotnet --version") != -1

--- a/full/tests/lang-dotnet.yaml
+++ b/full/tests/lang-dotnet.yaml
@@ -1,4 +1,6 @@
-- desc: it should run
-  command: [dotnet, version]
-  assert:
-    - status == 0
+- desc: it should run dotnet
+   command: [dotnet --version]
+   entrypoint: [bash, -i, -c]
+   assert:
+   - status == 0
+   - stdout.indexOf("dotnet") != -1

--- a/full/tests/lang-dotnet.yaml
+++ b/full/tests/lang-dotnet.yaml
@@ -1,0 +1,5 @@
+- desc: it should run
+  command: [dotnet, version]
+  assert:
+    - status == 0
+    - stdout.indexOf("dotnet --version") != -1


### PR DESCRIPTION
## Description

Includes Microsoft .NET by default into workspace-full

## How to test

$ dotnet --version

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- Include Microsoft .NET in the default workspace image
```

