### PR TITLE
feat: Add workspace-dotnet to workspace-full

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -278,6 +278,16 @@ RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
   && nix-env -iA cachix -f https://cachix.org/api/v1/install \
   && cachix use cachix
 
+### Install .NET SDK (Current channel)
+# Source: https://docs.microsoft.com/dotnet/core/install/linux-scripted-manual#scripted-install
+LABEL dazzle/layer=lang-dotnet
+LABEL dazzle/test=tests/lang-dotnet.yaml
+RUN mkdir -p /home/gitpod/dotnet && \
+	curl -fsSL https://dot.net/v1/dotnet-install.sh \
+	| bash /dev/stdin --channel Current --install-dir /home/gitpod/dotnet
+ENV DOTNET_ROOT=/home/gitpod/dotnet
+ENV PATH=$PATH:/home/gitpod/dotnet
+
 ### Prologue (built across all layers) ###
 LABEL dazzle/layer=dazzle-prologue
 LABEL dazzle/test=tests/prologue.yaml

--- a/full/tests/lang-dotnet.yaml
+++ b/full/tests/lang-dotnet.yaml
@@ -1,0 +1,9 @@
+- desc: it should run dotnet with a fully configured environment
+  command: [dotnet, --info]
+  entrypoint: [bash, -i, -c]
+  assert:
+  - status == 0
+  - stdout.indexOf(".NET SDK") != -1
+  - stdout.indexOf("/home/gitpod/dotnet/sdk") != -1
+  - stdout.indexOf("/home/gitpod/dotnet/shared/Microsoft.AspNetCore.App") != -1
+  - stdout.indexOf("/home/gitpod/dotnet/shared/Microsoft.NETCore.App") != -1


### PR DESCRIPTION
## Description
Adds `workspace-dotnet` to `workspace-full` image

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Closes #556

## How to test
<!-- Provide steps to test this PR -->
- Open this PR in Gitpod
- Run:
```bash
cd full && docker build -f Dockerfile -t full .
docker run -t full dotnet --info
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
!workspace-dotnet is no longer necessary except for backwards-compatibility
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

Will need to update [this page](https://www.gitpod.io/docs/languages/dotnet#installing-the-.net-tools).
