### PR TITLE
Trigger base image rebuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   validate-changes:
     docker:
       # pre-commit package is included since 20.10
-      - image: ubuntu:20.10
+      - image: ubuntu:22.04
     steps:
       - checkout
       - attach_workspace:
@@ -12,6 +12,7 @@ jobs:
       - run:
           name: Run pre-commit checks
           command: |
+            export DEBIAN_FRONTEND=noninteractive
             apt update && apt install -y shellcheck pre-commit git
             pre-commit run --all-files
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -33,6 +33,8 @@ RUN yes | unminimize \
 
 ENV LANG=en_US.UTF-8
 
+ENV TRIGGER_REBUILD=1
+
 ### Update and upgrade the base image ###
 RUN upgrade-packages
 


### PR DESCRIPTION
The ca-certificates of the base image are outdated and several other
packages need update. Retriggering base layer will fix these issues.

fixes https://github.com/gitpod-io/workspace-images/issues/599