### PR TITLE
Update Rust to 1.58.0

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -184,7 +184,7 @@ LABEL dazzle/layer=lang-rust
 LABEL dazzle/test=tests/lang-rust.yaml
 USER gitpod
 RUN cp /home/gitpod/.profile /home/gitpod/.profile_orig && \
-    curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.56.1 \
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.58.0 \
     && .cargo/bin/rustup component add \
         rls \
         rust-analysis \


### PR DESCRIPTION
Rust 1.58.0 introduces some cool stuff like format strings that I’d like to take advantage of.