### PR TITLE
[full] Upgrade to Ruby 3.0.3

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -167,8 +167,8 @@ RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import - \
     && curl -fsSL https://get.rvm.io | bash -s stable \
     && bash -lc " \
         rvm requirements \
-        && rvm install 2.7.4 \
-        && rvm use 2.7.4 --default \
+        && rvm install 3.0.3 \
+        && rvm use 3.0.3 --default \
         && rvm rubygems current \
         && gem install bundler --no-document \
         && gem install solargraph --no-document" \


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Upgrade Ruby from 2.7.4 to 3.0.3 in full image

## Related Issue(s)
Fixes #407

## How to test
Launch a workspace on Gitpod.

## Release Notes
```release-note
Bump ruby to 3.0.3
```

## Documentation
* No
  * Are you sure? If so, nothing to do here.
  * Sure
