### PR TITLE
Add ENV to retrigger repo's image build to use latest image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,7 @@
 FROM gitpod/workspace-full
 
+ENV RETRIGGER=1
+
 ENV BUILDKIT_VERSION=0.9.3
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add an ENV to the .gitpod.Dockerfile in order to trigger creation of a new docker image.
We recently published a new workspace-full image which was created dazzle rewrite.
This will enable us to dogfood.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # NA

## How to test
<!-- Provide steps to test this PR -->
Open this PR in a workspace.
Run `./dazzle-up.sh`. If the build starts then success.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
