### PR TITLE
Use full image for combinations derived from legacy images

### DIFF
--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -72,23 +72,23 @@ combiner:
         - lang-rust
     - name: dotnet-vnc
       ref:
-      - base
+      - full
       chunks:
         - tool-vnc
         - tool-dotnet
     - name: postgresql
       ref:
-      - base
+      - full
       chunks:
         - tool-postgresql
     - name: mysql
       ref:
-      - base
+      - full
       chunks:
         - tool-mysql
     - name: mongodb
       ref:
-      - base
+      - full
       chunks:
         - tool-mongodb
     - name: java-11


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change the base images to workspace-full for the images that had full in the legacy image.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/675

## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use full image as base for dotnet-vnc, mysql, postgreql and mongodb
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
