### PR TITLE
feat(nix): bump version to 2.6.0

### DIFF
--- a/chunks/tool-nix/Dockerfile
+++ b/chunks/tool-nix/Dockerfile
@@ -2,6 +2,7 @@ ARG base
 FROM ${base}
 
 ARG NIX_VERSION
+ARG NIX_CONFIG=""
 
 ENV NIX_VERSION=${NIX_VERSION}
 
@@ -25,6 +26,7 @@ RUN curl https://nixos.org/releases/nix/nix-$NIX_VERSION/install | sh
 
 RUN echo '. /home/gitpod/.nix-profile/etc/profile.d/nix.sh' >> /home/gitpod/.bashrc.d/200-nix
 RUN mkdir -p /home/gitpod/.config/nixpkgs && echo '{ allowUnfree = true; }' >> /home/gitpod/.config/nixpkgs/config.nix
+RUN mkdir -p /home/gitpod/.config/nix && echo $NIX_CONFIG >> /home/gitpod/.config/nix/nix.conf
 
 # Install cachix
 RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \

--- a/chunks/tool-nix/chunk.yaml
+++ b/chunks/tool-nix/chunk.yaml
@@ -2,3 +2,7 @@ variants:
   - name: "2.3.14"
     args:
       NIX_VERSION: 2.3.14
+  - name: "2.6.0"
+    args:
+      NIX_VERSION: 2.6.0
+      NIX_CONFIG: "experimental-features = nix-command flakes"

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -29,7 +29,7 @@ combiner:
         - lang-rust
         - tool-brew
         - tool-nginx
-        - tool-nix:2.3.14
+        - tool-nix:2.6.0
     - name: full-vnc
       ref:
       - full

--- a/tests/tool-nix.yaml
+++ b/tests/tool-nix.yaml
@@ -8,4 +8,5 @@
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("2.3.14") != -1
+  - stdout.indexOf("2.3.14") != -1 ||
+    stdout.indexOf("2.6.0")  != -1


### PR DESCRIPTION
## Description
Upgrades the version of nix to the latest release (2.6.0). This includes the major 2.4 update, which introduced support for features such as flakes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
Open a workspace with this image
```shell
gitpod ~ $ nix --version
nix (Nix) 2.6.0
gitpod ~ $ nix run "nixpkgs#hello"
Hello, world!
gitpod ~ $ 
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
- Bump nix to 2.6.0
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
