### PR TITLE
Adding ability to specify a custom user

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,6 +4,7 @@ COPY install-packages upgrade-packages /usr/bin/
 
 ### base ###
 ARG DEBIAN_FRONTEND=noninteractive
+ARG USER=gitpod
 
 RUN yes | unminimize \
     && install-packages \
@@ -40,23 +41,24 @@ RUN upgrade-packages
 RUN add-apt-repository -y ppa:git-core/ppa \
     && install-packages git git-lfs
 
+ENV HOME=/home/$USER
 ### Gitpod user ###
 # '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
+RUN useradd -l -u 33333 -G sudo -md $HOME -s /bin/bash -p $USER $USER \
     # passwordless sudo for users in the 'sudo' group
     && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
-ENV HOME=/home/gitpod
+
 WORKDIR $HOME
 # custom Bash prompt
 RUN { echo && echo "PS1='\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$(__git_ps1 \" (%s)\") $ '" ; } >> .bashrc
 
 ### Gitpod user (2) ###
-USER gitpod
+USER $USER
 # use sudo so that user does not get sudo usage info on (the first) login
-RUN sudo echo "Running 'sudo' for Gitpod: success" && \
+RUN sudo echo "Running 'sudo' for $HOME: success" && \
     # create .bashrc.d folder and source it in the bashrc
-    mkdir -p /home/gitpod/.bashrc.d && \
-    (echo; echo "for i in \$(ls -A \$HOME/.bashrc.d/); do source \$HOME/.bashrc.d/\$i; done"; echo) >> /home/gitpod/.bashrc
+    mkdir -p $HOME/.bashrc.d && \
+    (echo; echo "for i in \$(ls -A \$HOME/.bashrc.d/); do source \$HOME/.bashrc.d/\$i; done"; echo) >> $HOME/.bashrc
 
 # configure git-lfs
 RUN sudo git lfs install --system


### PR DESCRIPTION
## Description
Using gitpod workspace image with a custom username 
Closes #695 
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- Build docker with user build args 
 docker build   --build-arg USER=mwaaas    --tag=test -f base/Dockerfile ./base/
 
 then docker run test $(whoami) should print mwaaas

repeat the same process without specifying user it should print gitpod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```
- Possible to specify user on build 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
