### PR TITLE
Add GH action workflow to triage issues and PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,21 @@
+name: Issue and PR Triage
+on:
+  pull_request:
+    types: [review_requested]
+  issues:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  triage:
+    name: Triage issue/PR
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Add team label
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "team: workspace"
+      - name: Assign to Project
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        with:
+          project: 'https://github.com/orgs/gitpod-io/projects/16'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add labels and assign to project all the new issues and PRs which are requested for review.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/666

## How to test
<!-- Provide steps to test this PR -->
Can only be tested post merge.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
