### PR TITLE
fix(tool-postgresql): Non-existent /workspace dir

### DIFF
--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -20,9 +20,11 @@ RUN PGDATA="${PGDATA//\/workspace/$HOME}" \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
  && chmod +x ~/.pg_ctl/bin/* \
  && printf '%s\n' '# Auto-start PostgreSQL server' \
-                  "test ! -e \$PGWORKSPACE && mkdir -p /workspace && test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \
+                  "test ! -e \$PGWORKSPACE && test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \
                   # Making the /workspace dir just to make sure it doesnt fail in docker env in case
-                  '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' > ~/.bashrc.d/200-postgresql-launch
+                  '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' > ~/.bashrc.d/200-postgresql-launch \
+ # Just to emulate the workspace-session behavior within docker-build env
+ && sudo bash -c 'mkdir -p /workspace && chown -hR gitpod:gitpod /workspace'
 ENV PATH="$HOME/.pg_ctl/bin:$PATH"
 ENV DATABASE_URL="postgresql://gitpod@localhost"
 ENV PGHOSTADDR="127.0.0.1"

--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -20,7 +20,7 @@ RUN PGDATA="${PGDATA//\/workspace/$HOME}" \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
  && chmod +x ~/.pg_ctl/bin/* \
  && printf '%s\n' '# Auto-start PostgreSQL server' \
-                  "test ! -e \$PGWORKSPACE && mkdir -p /workspace && test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \ 
+                  "test ! -e \$PGWORKSPACE && mkdir -p /workspace && test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \
                   # Making the /workspace dir just to make sure it doesnt fail in docker env in case
                   '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' > ~/.bashrc.d/200-postgresql-launch
 ENV PATH="$HOME/.pg_ctl/bin:$PATH"

--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -1,14 +1,10 @@
 ARG base
 FROM ${base}
 
-USER gitpod
-
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=2
 ENV PGWORKSPACE="/workspace/.pgsql"
 ENV PGDATA="$PGWORKSPACE/data"
-RUN sudo mkdir -p $PGDATA
-RUN sudo chown gitpod $PGWORKSPACE -R
 
 # Install PostgreSQL
 RUN sudo install-packages postgresql-12 postgresql-contrib-12
@@ -16,18 +12,20 @@ RUN sudo install-packages postgresql-12 postgresql-contrib-12
 # Setup PostgreSQL server for user gitpod
 ENV PATH="/usr/lib/postgresql/12/bin:$PATH"
 
-RUN mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets \
+SHELL ["/usr/bin/bash", "-c"]
+RUN PGDATA="${PGDATA//\/workspace/$HOME}" \
+ && mkdir -p ~/.pg_ctl/bin ~/.pg_ctl/sockets $PGDATA \
  && initdb -D $PGDATA \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
- && chmod +x ~/.pg_ctl/bin/*
+ && chmod +x ~/.pg_ctl/bin/* \
+ && printf '%s\n' '# Auto-start PostgreSQL server' \
+                  "test ! -e \$PGWORKSPACE && mkdir -p /workspace && test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \ 
+                  # Making the /workspace dir just to make sure it doesnt fail in docker env in case
+                  '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' > ~/.bashrc.d/200-postgresql-launch
 ENV PATH="$HOME/.pg_ctl/bin:$PATH"
 ENV DATABASE_URL="postgresql://gitpod@localhost"
 ENV PGHOSTADDR="127.0.0.1"
 ENV PGDATABASE="postgres"
 
-# This is a bit of a hack. At the moment we have no means of starting background
-# tasks from a Dockerfile. This workaround checks, on each bashrc eval, if the
-# PostgreSQL server is running, and if not starts it.
-RUN printf "\n# Auto-start PostgreSQL server.\n[[ \$(pg_ctl status | grep PID) ]] || pg_start > /dev/null\n" >> /home/gitpod/.bashrc.d/200-postgresql-launch
-RUN chmod +x /home/gitpod/.bashrc.d/200-postgresql-launch
+USER gitpod

--- a/tests/tool-postgresql.yaml
+++ b/tests/tool-postgresql.yaml
@@ -5,7 +5,7 @@
   - status == 0
   - stdout.indexOf("(PostgreSQL) 12") != -1
 - desc: it should find data folder
-  command: [ls, /workspace/.pgsql/data]
+  command: [ls, ~/.pgsql/data]
   assert:
   - status == 0
 - desc: it should serve postgres

--- a/tests/tool-postgresql.yaml
+++ b/tests/tool-postgresql.yaml
@@ -4,10 +4,6 @@
   assert:
   - status == 0
   - stdout.indexOf("(PostgreSQL) 12") != -1
-- desc: it should find data folder
-  command: [ls, ~/.pgsql/data]
-  assert:
-  - status == 0
 - desc: it should serve postgres
   entrypoint: [bash, -i, -c]
   command: [psql -l]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`/workspace` dir is non-existent and will get overlapped by gitpod bind mounts on `/workspace` during workspace start.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #705 

## How to test
<!-- Provide steps to test this PR -->
https://gitpod.io/#https://github.com/axonasif/test/tree/postgresql-test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
