### PR TITLE
Fix env variable name for workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -46,12 +46,11 @@ jobs:
           TEAM_SLUG: engineering-workspace
         run: |
           gh api graphql -f query='
-            query($org: String!) {
+            query($org: String!, $slug: String!) {
               organization(login: $org){
-                nodes {
-                  team(slug: $slug) {
-                    id
-                  }
+                id
+                team(slug: $slug) {
+                  id
                 }
               }
             }' -f org=$ORGANIZATION -f slug=$TEAM_SLUG

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -17,13 +17,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
           ORGANIZATION: gitpod-io
+          TEAM_SLUG: engineering-workspace
           PROJECT_NUMBER: 16
         run: |
           gh api graphql -f query='
-            query($org: String!, $number: Int!) {
+            query($org: String!, $slug: String!, $number: Int!) {
               organization(login: $org){
                 projectNext(number: $number) {
                   id
+                  team(slug: $slug) {
+                    id
+                  }
                   fields(first:20) {
                     nodes {
                       id
@@ -33,27 +37,30 @@ jobs:
                   }
                 }
               }
-            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+            }' -f org=$ORGANIZATION -f slug=$TEAM_SLUG -F number=$PROJECT_NUMBER > project_data.json
 
           echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
           echo 'IN_PROGRESS_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="In Progress") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'TEAM_ID='$(jq '.data.organization.team.id' project_data.json) >> $GITHUB_ENV
+          cat project_data.json
+      # - name: Get team data
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+      #     ORGANIZATION: gitpod-io
+      #     TEAM_SLUG: engineering-workspace
+      #   run: |
+      #     gh api graphql -f query='
+      #       query($org: String!, $slug: String!) {
+      #         organization(login: $org){
+      #           id
+      #           team(slug: $slug) {
+      #             id
+      #           }
+      #         }
+      #       }' -f org=$ORGANIZATION -f slug=$TEAM_SLUG > team_data.json
 
-      - name: Get team data
-        env:
-          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
-          ORGANIZATION: gitpod-io
-          TEAM_SLUG: engineering-workspace
-        run: |
-          gh api graphql -f query='
-            query($org: String!, $slug: String!) {
-              organization(login: $org){
-                id
-                team(slug: $slug) {
-                  id
-                }
-              }
-            }' -f org=$ORGANIZATION -f slug=$TEAM_SLUG
+      #     echo 'TEAM_ID='$(jq '.data.organization.team.id' project_data.json) >> $GITHUB_ENV
 
       - name: Add PR to project
         if: github.event_name == 'pull_request'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -23,11 +23,12 @@ jobs:
           gh api graphql -f query='
             query($org: String!, $slug: String!, $number: Int!) {
               organization(login: $org){
+                id
+                team(slug: $slug) {
+                  id
+                }
                 projectNext(number: $number) {
                   id
-                  team(slug: $slug) {
-                    id
-                  }
                   fields(first:20) {
                     nodes {
                       id

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,8 +4,6 @@ on:
     types: [review_requested]
   issues:
     types: [opened]
-env:
-  GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
 jobs:
   triage:
     name: Triage issue/PR
@@ -15,7 +13,17 @@ jobs:
         uses: andymckay/labeler@1.0.4
         with:
           add-labels: "team: workspace"
-      - name: Assign to Project
-        uses: srggrs/assign-one-project-github-action@1.2.1
+      - name: Assign PR to Project
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        if: github.event_name == 'pull_request'
         with:
           project: 'https://github.com/orgs/gitpod-io/projects/16'
+          column: 'In Progress'
+          repo-token: ${{ secrets.LABELER_TOKEN }}
+      - name: Assign Issue to Project
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        if: github.event_name == 'issues'
+        with:
+          project: 'https://github.com/orgs/gitpod-io/projects/16'
+          column: 'No status'
+          repo-token: ${{ secrets.LABELER_TOKEN }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -36,10 +36,25 @@ jobs:
             }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
 
           echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
-          echo 'DATE_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Date posted") | .id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
-          echo 'TODO_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="Todo") |.id' project_data.json) >> $GITHUB_ENV
           echo 'IN_PROGRESS_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="In Progress") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Get team data
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+          ORGANIZATION: gitpod-io
+          TEAM_SLUG: engineering-workspace
+        run: |
+          gh api graphql -f query='
+            query($org: String!) {
+              organization(login: $org){
+                nodes {
+                  team(slug: $slug) {
+                    id
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -f slug=$TEAM_SLUG
 
       - name: Add PR to project
         if: github.event_name == 'pull_request'
@@ -58,55 +73,43 @@ jobs:
           
           echo 'ITEM_ID='$item_id >> $GITHUB_ENV
 
-      # - name: Get date
-      #   run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+      - name: Set PR status
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: $status_value
+              }) {
+                projectNextItem {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_PROGRESS_OPTION_ID }} --silent
 
-      # - name: Set fields
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
-      #   run: |
-      #     gh api graphql -f query='
-      #       mutation (
-      #         $project: ID!
-      #         $item: ID!
-      #         $status_field: ID!
-      #         $status_value: String!
-      #         $date_field: ID!
-      #         $date_value: String!
-      #       ) {
-      #         set_status: updateProjectNextItemField(input: {
-      #           projectId: $project
-      #           itemId: $item
-      #           fieldId: $status_field
-      #           value: $status_value
-      #         }) {
-      #           projectNextItem {
-      #             id
-      #             }
-      #         }
-      #         set_date_posted: updateProjectNextItemField(input: {
-      #           projectId: $project
-      #           itemId: $item
-      #           fieldId: $date_field
-      #           value: $date_value
-      #         }) {
-      #           projectNextItem {
-      #             id
-      #           }
-      #         }
-      #       }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.TODO_OPTION_ID }} -f date_field=$DATE_FIELD_ID -f date_value=$DATE --silent
-
-      # - name: Assign PR to Project
-      #   uses: alex-page/github-project-automation-plus@v0.8.1
-      #   if: github.event_name == 'pull_request'
-      #   with:
-      #     project: 'https://github.com/orgs/gitpod-io/projects/16'
-      #     column: 'In Progress'
-      #     repo-token: ${{ secrets.LABELER_TOKEN }}
-      # - name: Assign Issue to Project
-      #   uses: alex-page/github-project-automation-plus@v0.8.1
-      #   if: github.event_name == 'issues'
-      #   with:
-      #     project: 'https://github.com/orgs/gitpod-io/projects/16'
-      #     column: 'No status'
-      #     repo-token: ${{ secrets.LABELER_TOKEN }}
+      - name: Add Issue to project
+        if: github.event_name == 'issues'
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+          ISSUE_ID: ${{ github.event.issues.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+          
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 name: Issue and PR Triage
 on:
   pull_request:
-    types: [review_requested]
+    types: [ready_for_review]
   issues:
     types: [opened]
 jobs:
@@ -13,17 +13,100 @@ jobs:
         uses: andymckay/labeler@1.0.4
         with:
           add-labels: "team: workspace"
-      - name: Assign PR to Project
-        uses: alex-page/github-project-automation-plus@v0.8.1
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+          ORGANIZATION: gitpod-io
+          PROJECT_NUMBER: 16
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          echo 'DATE_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Date posted") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'TODO_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="Todo") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'IN_PROGRESS_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="In Progress") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add PR to project
         if: github.event_name == 'pull_request'
-        with:
-          project: 'https://github.com/orgs/gitpod-io/projects/16'
-          column: 'In Progress'
-          repo-token: ${{ secrets.LABELER_TOKEN }}
-      - name: Assign Issue to Project
-        uses: alex-page/github-project-automation-plus@v0.8.1
-        if: github.event_name == 'issues'
-        with:
-          project: 'https://github.com/orgs/gitpod-io/projects/16'
-          column: 'No status'
-          repo-token: ${{ secrets.LABELER_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+          
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      # - name: Get date
+      #   run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+
+      # - name: Set fields
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
+      #   run: |
+      #     gh api graphql -f query='
+      #       mutation (
+      #         $project: ID!
+      #         $item: ID!
+      #         $status_field: ID!
+      #         $status_value: String!
+      #         $date_field: ID!
+      #         $date_value: String!
+      #       ) {
+      #         set_status: updateProjectNextItemField(input: {
+      #           projectId: $project
+      #           itemId: $item
+      #           fieldId: $status_field
+      #           value: $status_value
+      #         }) {
+      #           projectNextItem {
+      #             id
+      #             }
+      #         }
+      #         set_date_posted: updateProjectNextItemField(input: {
+      #           projectId: $project
+      #           itemId: $item
+      #           fieldId: $date_field
+      #           value: $date_value
+      #         }) {
+      #           projectNextItem {
+      #             id
+      #           }
+      #         }
+      #       }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.TODO_OPTION_ID }} -f date_field=$DATE_FIELD_ID -f date_value=$DATE --silent
+
+      # - name: Assign PR to Project
+      #   uses: alex-page/github-project-automation-plus@v0.8.1
+      #   if: github.event_name == 'pull_request'
+      #   with:
+      #     project: 'https://github.com/orgs/gitpod-io/projects/16'
+      #     column: 'In Progress'
+      #     repo-token: ${{ secrets.LABELER_TOKEN }}
+      # - name: Assign Issue to Project
+      #   uses: alex-page/github-project-automation-plus@v0.8.1
+      #   if: github.event_name == 'issues'
+      #   with:
+      #     project: 'https://github.com/orgs/gitpod-io/projects/16'
+      #     column: 'No status'
+      #     repo-token: ${{ secrets.LABELER_TOKEN }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix environment variable name for `triage.yml` workflow.
The Actions [readme](https://github.com/srggrs/assign-one-project-github-action#organisation-or-user-project) suggests to use env var `MY_GITHUB_TOKEN` instead of `GITHUB_TOKEN` for organisation level project.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes NA

## How to test
<!-- Provide steps to test this PR -->
Can be only tested after merge to default branch.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
