### PR TITLE
Use GAR to build images for pull-request.yml workflow

### DIFF
--- a/.github/update-dazzle-for-pr.py
+++ b/.github/update-dazzle-for-pr.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import sys
+import shutil
+from ruamel.yaml import YAML
+
+
+n = len(sys.argv)
+if n != 2:
+    raise Exception(
+        "mandatory argument <suffix> missing, use update-dazzle-for-pr.py <suffix>")
+
+suffix = sys.argv[1]
+
+if len(suffix) == 0:
+    raise Exception("mandatory argument <suffix> should not be empty")
+
+# take backup
+shutil.copy2("dazzle.yaml", "dazzle.yaml.orig")
+
+yaml = YAML(typ="safe")
+
+fp = open("dazzle.yaml.orig")
+data = yaml.load(fp)
+fp.close()
+
+# add suffix '-<suffix>' to all the combo names and the references
+for combo in data["combiner"]["combinations"]:
+    combo["name"] += "-" + suffix
+    if "ref" in combo:
+        for i in range(len(combo["ref"])):
+            combo["ref"][i] += "-" + suffix
+
+final_fp = open("dazzle.yaml", "w")
+yaml.dump(data, final_fp)
+final_fp.close()

--- a/.github/update-dazzle-for-pr.py
+++ b/.github/update-dazzle-for-pr.py
@@ -19,9 +19,9 @@ shutil.copy2("dazzle.yaml", "dazzle.yaml.orig")
 
 yaml = YAML(typ="safe")
 
-fp = open("dazzle.yaml.orig")
-data = yaml.load(fp)
-fp.close()
+with open("dazzle.yaml.orig") as fp:
+    data = yaml.load(fp)
+    fp.close()
 
 # add suffix '-<suffix>' to all the combo names and the references
 for combo in data["combiner"]["combinations"]:
@@ -30,6 +30,6 @@ for combo in data["combiner"]["combinations"]:
         for i in range(len(combo["ref"])):
             combo["ref"][i] += "-" + suffix
 
-final_fp = open("dazzle.yaml", "w")
-yaml.dump(data, final_fp)
-final_fp.close()
+with open("dazzle.yaml", "w") as final_fp:
+    yaml.dump(data, final_fp)
+    final_fp.close()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: "pull-request"
+    permissions:
+      contents: "read"
+      id-token: "write"
+    env:
+      WORKLOAD_IDENTITY_POOL_ID: projects/665270063338/locations/global/workloadIdentityPools/workspace-images-gh-actions-pr/providers/workspace-images-gha-provider-pr
+      GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
+      IAM_SERVICE_ACCOUNT: workspace-images-gha-pr-sa@gitpod-artifacts.iam.gserviceaccount.com
     steps:
       - name: 📥 Checkout workspace-images
         uses: actions/checkout@v2
@@ -33,30 +41,34 @@ jobs:
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock
 
-      # A hack as GH action does not allow you to force override cache storing if there was a cache hit
-      # https://github.com/actions/cache/issues/628#issuecomment-986118455
-      - name: 🗄️ Force Save Registry Cache Per Sha
-        uses: actions/cache@v2
-        with:
-          path: ~/registry
-          key: ${{ runner.os }}-pull-request-cache-${{ github.sha }}
-
-      - name: 🗄️ Restore Registry Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/registry
-          key: ${{ runner.os }}-pull-request-cache-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-pull-request-cache-
-
-      - name: 📦 Setup local registry
+      - name: 🤓 Update dazzle.yaml
         run: |
-          docker run -it --detach --publish 5000:5000 --volume ~/registry:/var/lib/registry registry:2
+          pip3 install ruamel.yaml
+          python3 .github/update-dazzle-for-pr.py ${{ github.event.pull_request.number }}
+          echo "Updated dazzle.yaml:"
+          cat dazzle.yaml
+
+      - name: ☁️ Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          version: 366.0.0
+
+      - name: 🔐 Authenticate to Google Cloud
+        id: "auth"
+        uses: "google-github-actions/auth@v0.4.3"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
+          service_account: ${{env.IAM_SERVICE_ACCOUNT}}
+
+      - name: ✍🏽 Login to GAR using docker
+        run: |
+          docker login -u oauth2accesstoken --password=${{ steps.auth.outputs.access_token }} https://${{env.GAR_IMAGE_REGISTRY}}
 
       - name: 🔨 Dazzle build
         run: |
-          dazzle build localhost:5000/workspace-base-images
+          dazzle build ${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr
 
       - name: 🖇️ Dazzle combine
         run: |
-          dazzle combine localhost:5000/workspace-base-images --all
+          dazzle combine ${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr --all


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use GAR to build images instead of local registry.
This would enable faster builds as GAR would house the previously built chunks.
Modify dazzle.yaml file to rename the combination so that two PRs do not race to write to the same tag.
Use PR number suffix to distinguish builds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes partially https://github.com/gitpod-io/workspace-images/issues/713

## How to test
<!-- Provide steps to test this PR -->
See the pull-request.yml action for this PR. It is already using GAR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
