### PR TITLE
Delete older image tags and layers for docker-dev-pr/workspace-base-images-pr image

### DIFF
--- a/.github/gargc.sh
+++ b/.github/gargc.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Inspired from https://gist.github.com/ahmetb/7ce6d741bd5baa194a3fac6b1fec8bb7
+
+IFS=$'\n\t'
+set -eou pipefail
+
+if [[ "$#" -ne 2 || "${1}" == '-h' || "${1}" == '--help' ]]; then
+	cat >&2 <<"EOF"
+gargc.sh cleans up tagged or untagged images pushed before specified date
+for a given image
+USAGE:
+  gargc.sh REPOSITORY DATE
+EXAMPLE
+  gargc.sh  europe-docker.pkg.dev/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr 2017-04-01
+  would clean up all images tags pushed before 2017-04-01 for
+  europe-docker.pkg.dev/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr image.
+EOF
+	exit 1
+elif [[ "${#2}" -ne 10 ]]; then
+	echo "wrong DATE format; use YYYY-MM-DD." >&2
+	exit 1
+fi
+
+main() {
+	local C=0
+	IMAGE="${1}"
+	DATE="${2}"
+	for digest in $(gcloud artifacts docker images list "${IMAGE}" --limit=999999 \
+		--filter="updateTime<${DATE}" --format='value(version)'); do
+		(
+			gcloud artifacts docker images delete "${IMAGE}@${digest}" --delete-tags --quiet
+		)
+		((C++)) || true
+	done
+	echo "Deleted ${C} images in ${IMAGE}." >&2
+}
+
+main "${1}" "${2}"

--- a/.github/gargc.sh
+++ b/.github/gargc.sh
@@ -13,7 +13,7 @@ USAGE:
   gargc.sh REPOSITORY DATE
 EXAMPLE
   gargc.sh  europe-docker.pkg.dev/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr 2017-04-01
-  would clean up all images tags pushed before 2017-04-01 for
+  would clean up all images tags pushed before 2017-04-01 (i.e. < 2017-04-01 ) for
   europe-docker.pkg.dev/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr image.
 EOF
 	exit 1

--- a/.github/workflows/pr-registry-cleanup.yml
+++ b/.github/workflows/pr-registry-cleanup.yml
@@ -1,0 +1,44 @@
+name: Delete PR registry images
+on:
+  schedule:
+  # At 04:07 everyday. We choose such time as github recommends not choosing hourly timings
+  # like 04:00 to avoid schedule job congestions
+  - cron: 7 4 * * *
+
+jobs:
+  # delete the image tags and layers which are older than 4 days
+  # this job is supposed to run everyday.
+  delete:
+    runs-on: ubuntu-latest
+    environment: "pull-request"
+    permissions:
+      contents: "read"
+      id-token: "write"
+    env:
+      WORKLOAD_IDENTITY_POOL_ID: projects/665270063338/locations/global/workloadIdentityPools/workspace-images-gh-actions-pr/providers/workspace-images-gha-provider-pr
+      GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
+      IAM_SERVICE_ACCOUNT: workspace-images-gha-pr-sa@gitpod-artifacts.iam.gserviceaccount.com
+    steps:
+      - name: 📥 Checkout workspace-images
+        uses: actions/checkout@v2
+        with:
+          repository: gitpod-io/workspace-images
+
+      - name: ☁️ Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          version: 366.0.0
+
+      - name: 🔐 Authenticate to Google Cloud
+        id: "auth"
+        uses: "google-github-actions/auth@v0.4.3"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
+          service_account: ${{env.IAM_SERVICE_ACCOUNT}}
+
+      - name: 🖇️ Clean up images older than 4 days
+        run: |
+          TODAY=$(date '+%Y-%m-%d')
+          DELETE_DATE=$(date --date="${TODAY} -4 day" +%Y-%m-%d)
+          .github/gargc.sh ${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev-pr/workspace-base-images-pr ${DELETE_DATE}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Every PR results in creation of images and layers. These are stored in the GAR. We don't need layers created from old PRs which are merged. Since there is no way to identify the sha of a layer based on the PR, we delete all the layers and tags in the GAR which are older than 4 days. In some cases when a PR is open longer than 4 days a manual retrigger of build or a new push to the PR will result in rebuilding of layers. This is not so bad considering the amount of storage the stale layers will consume.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially Fixes https://github.com/gitpod-io/workspace-images/issues/713

## How to test
<!-- Provide steps to test this PR -->
I tested the changes by [triggering them on a pull_request](https://github.com/gitpod-io/workspace-images/runs/5350633387?check_suite_focus=true) event and it succeeded.
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
