### PR TITLE
Sync images tags to Dockerhub using manual Action

### DIFF
--- a/.github/registries.conf
+++ b/.github/registries.conf
@@ -1,2 +1,0 @@
-[registries.insecure]
-registries = ['localhost:5000']

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -1,0 +1,73 @@
+name: Publish latest images to Docker Hub
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Sync the 'latest' tag from GAR to Docker Hub
+  #
+  # From your GitHub repo clock Settings. In the left menu, click Environments.
+  # Click New environment, set the name production, and click Configure environment.
+  # Check the "Required reviewers" box and enter at least one user or team name.
+  promote-latest:
+    runs-on: ubuntu-latest
+    environment: "production"
+    permissions:
+      contents: "read"
+      id-token: "write"
+    env:
+      WORKLOAD_IDENTITY_POOL_ID: projects/665270063338/locations/global/workloadIdentityPools/workspace-images-github-actions/providers/workspace-images-gha-provider
+      GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
+      DH_IMAGE_REGISTRY: registry.hub.docker.com
+      IAM_SERVICE_ACCOUNT: workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com
+
+    steps:
+      - name: 📥 Checkout workspace-images
+        uses: actions/checkout@v2
+        with:
+          repository: gitpod-io/workspace-images
+
+      - name: 🔧 Setup tools
+        run: |
+          sudo apt-get install python3-pip
+          sudo pip3 install yq
+
+      - name: 🔆 Install skopeo
+        run: |
+          . /etc/os-release
+          # Update ca-certificates to avoid issues with letsencrypt SSL certificates
+          sudo apt update && sudo apt --only-upgrade install ca-certificates -y
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+          sudo apt update && sudo apt install -y skopeo
+
+      - name: ☁️ Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          version: 366.0.0
+
+      - name: 🔐 Authenticate to Google Cloud
+        id: "auth"
+        uses: "google-github-actions/auth@v0.4.3"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
+          service_account: ${{env.IAM_SERVICE_ACCOUNT}}
+
+      - name: ✍🏽 Login to GAR using skopeo
+        run: |
+          sudo skopeo login -u oauth2accesstoken --password=${{ steps.auth.outputs.access_token }} https://${{env.GAR_IMAGE_REGISTRY}}
+
+      - name: ✍🏽 Login to Docker Hub using skopeo
+        env:
+          docker_user: ${{ secrets.DOCKERHUB_USER_NAME }}
+          docker_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: |
+          sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} https://${{ env.DH_IMAGE_REGISTRY }}
+
+      - name: 🐳 Sync images to Docker Hub
+        run: |
+          sudo skopeo sync \
+            --src yaml \
+            --dest docker \
+            .github/promote-images.yml ${{ env.DH_IMAGE_REGISTRY }}/gitpod

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       WORKLOAD_IDENTITY_POOL_ID: projects/665270063338/locations/global/workloadIdentityPools/workspace-images-github-actions/providers/workspace-images-gha-provider
       GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
-      DH_IMAGE_REGISTRY: registry.hub.docker.com
       IAM_SERVICE_ACCOUNT: workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com
 
     steps:
@@ -108,7 +107,6 @@ jobs:
           do
             sudo skopeo copy \
             --src-tls-verify=false \
-            --registries-conf=.github/registries.conf \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:${{ env.TIMESTAMP_TAG }} &
 
@@ -116,7 +114,6 @@ jobs:
 
             sudo skopeo copy \
             --src-tls-verify=false \
-            --registries-conf=.github/registries.conf \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:latest &
 
@@ -127,17 +124,3 @@ jobs:
           for COPY_JOBS_PID in $COPY_JOBS_PIDS; do
               wait $COPY_JOBS_PID || exit 1
           done
-
-      - name: ✍🏽 Login to dockerhub using skopeo
-        env:
-          docker_user: ${{ secrets.DOCKERHUB_USER_NAME }}
-          docker_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-        run: |
-          sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} https://${{ env.DH_IMAGE_REGISTRY }}
-
-      - name: 🐳 Sync images to Docker Hub
-        run: |
-          sudo skopeo sync \
-            --src yaml \
-            --dest docker \
-            .github/promote-images.yml ${{ env.DH_IMAGE_REGISTRY }}/gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
### Original Behaviour
The `push-main.yml` workflow would build new images whenver there is a merge to the master branch.
It will rename and copy the images along with datetimestamp to GAR.
It will also retag the new image tag with `latest` tag.
It will push all the tags of images in GAR to Dockerhub via skopeo sync.


### New behaviour
Do not push new image tags from GAR to Docker hub when there are merges to master.
Create a new workflow `dockerhub-release.yml` which can be only triggered manually.
This workflow will copy all the tags including the `latest` tag of workspace images to Docker Hub from GAR.


## Other Changes
Additionally -  I removed the `registries.conf` file which is no more applicable as we switched to GAR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fix https://github.com/gitpod-io/workspace-images/issues/728

## How to test
<!-- Provide steps to test this PR -->
NA. Can be only tested after merge.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
