### PR TITLE
Update accesstoken lifetime to 5 hours

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -51,6 +51,7 @@ jobs:
         uses: google-github-actions/auth@v0.6.0
         with:
           token_format: "access_token"
+          access_token_lifetime: '18000s'
           workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
           service_account: ${{env.IAM_SERVICE_ACCOUNT}}
 

--- a/.github/workflows/image-promote.yml
+++ b/.github/workflows/image-promote.yml
@@ -47,6 +47,7 @@ jobs:
         uses: google-github-actions/auth@v0.6.0
         with:
           token_format: "access_token"
+          access_token_lifetime: '18000s'
           workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
           service_account: ${{env.IAM_SERVICE_ACCOUNT}}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: 🔐 Authenticate to Google Cloud
         id: "auth"
-        uses: google-github-actions/auth@v0.6.0
+        uses: google-github-actions/auth@v0
         with:
           token_format: "access_token"
           access_token_lifetime: '18000s'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,6 +58,7 @@ jobs:
         uses: google-github-actions/auth@v0.6.0
         with:
           token_format: "access_token"
+          access_token_lifetime: '18000s'
           workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
           service_account: ${{env.IAM_SERVICE_ACCOUNT}}
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -70,6 +70,7 @@ jobs:
         uses: google-github-actions/auth@v0.6.0
         with:
           token_format: "access_token"
+          access_token_lifetime: '18000s'
           workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
           service_account: ${{env.IAM_SERVICE_ACCOUNT}}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update the default timeout of google access token to 18000s or 5 hours to avoid access token expiration for a longer running action.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially Fixes https://github.com/gitpod-io/workspace-images/issues/713

## How to test
<!-- Provide steps to test this PR -->
The PR build should be green. Nothing to be tested manually.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
