### PR TITLE
Fix incorrect ISSUE_ID for triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -86,7 +86,7 @@ jobs:
         if: github.event_name == 'issues'
         env:
           GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
-          ISSUE_ID: ${{ github.event.issues.node_id }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
         run: |
           gh api graphql -f query='
             mutation($project:ID!, $issue:ID!) {
@@ -95,4 +95,4 @@ jobs:
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f pr=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix incorrect ISSUE_ID for triage workflow

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes failing triage workflow for issues e.g. [[1](https://github.com/gitpod-io/workspace-images/actions/runs/1906402367)]

## How to test
<!-- Provide steps to test this PR -->
Can be tested only post merge.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
