### PR TITLE
Get rid of PR assignment to Project

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 name: Issue and PR Triage
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened]
   issues:
     types: [opened]
 jobs:
@@ -15,6 +15,7 @@ jobs:
           add-labels: "team: workspace"
 
       - name: Get project data
+        if: github.event_name == 'issues'
         env:
           GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
           ORGANIZATION: gitpod-io
@@ -40,47 +41,6 @@ jobs:
           echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
           echo 'IN_PROGRESS_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="In Progress") |.id' project_data.json) >> $GITHUB_ENV
-
-      - name: Add PR to project
-        if: github.event_name == 'pull_request' && !github.event.pull_request.draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
-          PR_ID: ${{ github.event.pull_request.node_id }}
-        run: |
-          item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $pr:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
-                projectNextItem {
-                  id
-                }
-              }
-            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
-
-          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
-
-      - name: Set PR status in project
-        if: github.event_name == 'pull_request' && !github.event.pull_request.draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN }}
-        run: |
-          gh api graphql -f query='
-            mutation (
-              $project: ID!
-              $item: ID!
-              $status_field: ID!
-              $status_value: String!
-            ) {
-              set_status: updateProjectNextItemField(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $status_field
-                value: $status_value
-              }) {
-                projectNextItem {
-                    id
-                  }
-              }
-            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.IN_PROGRESS_OPTION_ID }} --silent
 
       - name: Add Issue to project
         if: github.event_name == 'issues'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To have a single source of truth, all PRs should be continued to be
listed using the team label instead of adding it to team project board.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NA

## How to test
<!-- Provide steps to test this PR -->
This can be only tested post merge.
The issue triage should continue to work and PRs should not get auto assigned to project after this is merged.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
