### PR TITLE
Promote date time stamped tags to Dockerhub

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -1,21 +1,24 @@
-# Sync all the image tags including latest
-europe-docker.pkg.dev/gitpod-artifacts/docker-dev:
-  images:
-    workspace-base: []
-    workspace-c: []
-    workspace-clojure: []
-    workspace-full: []
-    workspace-full-vnc: []
-    workspace-go: []
-    workspace-node: []
-    workspace-node-lts: []
-    workspace-python: []
-    workspace-ruby-2: []
-    workspace-ruby-3: []
-    workspace-rust: []
-    workspace-dotnet: []
-    workspace-postgresql: []
-    workspace-mysql: []
-    workspace-mongodb: []
-    workspace-java-11: []
-    workspace-java-17: []
+# Sync all the iamges that are tagged using date time stamp
+# format +%Y-%m-%d-%H-%M-%S e.g. 2022-02-22-10-10-54.
+# Use simple regex for readability. Since we tag all images with year
+# We use a regex rule: Any tag that starts with '20'.
+"europe-docker.pkg.dev/gitpod-artifacts/docker-dev":
+  images-by-tag-regex:
+    workspace-base: "20.*"
+    workspace-c: "20.*"
+    workspace-clojure: "20.*"
+    workspace-full: "20.*"
+    workspace-full-vnc: "20.*"
+    workspace-go: "20.*"
+    workspace-node: "20.*"
+    workspace-node-lts: "20.*"
+    workspace-python: "20.*"
+    workspace-ruby-2: "20.*"
+    workspace-ruby-3: "20.*"
+    workspace-rust: "20.*"
+    workspace-dotnet-vnc: "20.*"
+    workspace-postgresql: "20.*"
+    workspace-mysql: "20.*"
+    workspace-mongodb: "20.*"
+    workspace-java-11: "20.*"
+    workspace-java-17: "20.*"

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -65,9 +65,12 @@ jobs:
         run: |
           sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} https://${{ env.DH_IMAGE_REGISTRY }}
 
-      - name: 🐳 Sync images to Docker Hub
+      - name: 🐳 Sync latest tag of images to Docker Hub
         run: |
-          sudo skopeo sync \
-            --src yaml \
-            --dest docker \
-            .github/promote-images.yml ${{ env.DH_IMAGE_REGISTRY }}/gitpod
+          IMAGES=$(cat .github/promote-images.yml | yq '."europe-docker.pkg.dev/gitpod-artifacts/docker-dev"."images-by-tag-regex"|keys[]' -r)
+          for IMAGE in $IMAGES;
+          do
+            sudo skopeo copy \
+            docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/$IMAGE:latest \
+            docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest
+          done

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       WORKLOAD_IDENTITY_POOL_ID: projects/665270063338/locations/global/workloadIdentityPools/workspace-images-github-actions/providers/workspace-images-gha-provider
       GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
+      DH_IMAGE_REGISTRY: registry.hub.docker.com
       IAM_SERVICE_ACCOUNT: workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com
 
     steps:
@@ -106,14 +107,12 @@ jobs:
           for IMAGE_TAG in $IMAGE_TAGS;
           do
             sudo skopeo copy \
-            --src-tls-verify=false \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:${{ env.TIMESTAMP_TAG }} &
 
             COPY_JOBS_PIDS="$COPY_JOBS_PIDS $!"
 
             sudo skopeo copy \
-            --src-tls-verify=false \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:latest &
 
@@ -124,3 +123,17 @@ jobs:
           for COPY_JOBS_PID in $COPY_JOBS_PIDS; do
               wait $COPY_JOBS_PID || exit 1
           done
+
+      - name: ✍🏽 Login to Docker Hub using skopeo
+        env:
+          docker_user: ${{ secrets.DOCKERHUB_USER_NAME }}
+          docker_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: |
+          sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} https://${{ env.DH_IMAGE_REGISTRY }}
+
+      - name: 🐳 Sync images with specific tags to Docker Hub
+        run: |
+            sudo skopeo sync \
+            --src yaml \
+            --dest docker \
+            .github/promote-images.yml ${{ env.DH_IMAGE_REGISTRY }}/gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

### Current Behaviour
The `push-main.yml` workflow would build new images whenever there is a merge to the master branch.
It will rename and copy the images along with datetimestamp to GAR.
It will also retag the new image tag with `latest` tag.

The `dockerhub-release.yml` workflow syncs all tags of images from GAR to Docker Hub.

### New behaviour
The `push-main.yml` workflow will sync only date time stamp tagged images from GAR to dockerhub using skopeo.

The `dockerhub-release.yml` will copy only the `latest` tag of workspace images to Docker Hub from GAR.

So, everytime there is a merge to the master branch new set of images will be release to public on Docker Hub, however, it will not update the latest tag.
You can see [skopeo doc](https://github.com/containers/skopeo/blob/main/docs/skopeo-sync.1.md) to learn more on the yaml changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/752

## How to test
<!-- Provide steps to test this PR -->
Can be only tested on merge to master branch.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
