### PR TITLE
Ensure docker compose subcommand is available

### DIFF
--- a/chunks/tool-docker/Dockerfile
+++ b/chunks/tool-docker/Dockerfile
@@ -16,8 +16,9 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor
 RUN curl -o /usr/bin/slirp4netns -fsSL https://github.com/rootless-containers/slirp4netns/releases/download/v1.1.12/slirp4netns-$(uname -m) \
     && chmod +x /usr/bin/slirp4netns
 
-RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.2.2/docker-compose-linux-$(uname -m) \
-    && chmod +x /usr/local/bin/docker-compose
+RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-$(uname -m) \
+    && chmod +x /usr/local/bin/docker-compose && mkdir -p /usr/local/lib/docker/cli-plugins && \
+    ln -s /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
 
 # https://github.com/wagoodman/dive
 RUN curl -o /tmp/dive.deb -fsSL https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_linux_amd64.deb \

--- a/tests/tool-docker.yaml
+++ b/tests/tool-docker.yaml
@@ -8,7 +8,7 @@
   command: [docker-compose --version]
   assert:
   - status == 0
-  - stdout.indexOf("2.2.2") != -1
+  - stdout.indexOf("2.2.3") != -1
 - desc: containerd should be installed
   command: [containerd, config, dump]
   assert:


### PR DESCRIPTION
## Description
The docker compose command (_not_ docker-compose) is not available. We already download the binary but it is not in the location that docker expects. See [installation instructions.](https://docs.docker.com/compose/cli-command/#install-on-linux).

## Related Issue(s)
Fixes #577

## How to test
- Run workspace image with docker tools installed
- Call docker compose -> The command should be available

## Release Notes
```release-note
Make docker compose subcommand available
```