### PR TITLE
Fix release image regression for dotnet

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -16,7 +16,7 @@
     workspace-ruby-2: "20.*"
     workspace-ruby-3: "20.*"
     workspace-rust: "20.*"
-    workspace-dotnet-vnc: "20.*"
+    workspace-dotnet: "20.*"
     workspace-postgresql: "20.*"
     workspace-mysql: "20.*"
     workspace-mongodb: "20.*"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`dotnet-vnc` was reintroduced due to [bad copy-paste](https://github.com/gitpod-io/workspace-images/pull/753/files#diff-f3ecae09629802a1f735c45473eb2fb4389dfcc37fbea02d54bbfbf3c6901e26R19). Replace it with `dotnet`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes NA

## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
