### PR TITLE
Update default branch name to `main`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint workflows
 on:
   pull_request:
     branches:
-      - master
+      - main
       - "releases/*"
 
 jobs:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -3,7 +3,7 @@ name: Build from Main
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   # Build images using artifactory as image registry.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ We use [Github Actions](https://docs.github.com/en/actions) for our pipelines.
 
 We have a Build pipeline which gets triggered on the following two events:
 
-1. **[Build from Main](.github/workflows/push-main.yml)** - On push to the default branch `master`.
+1. **[Build from Main](.github/workflows/push-main.yml)** - On push to the default branch `main`.
 1. **[Build from Pull Request](.github/workflows/pull-request.yml)** - On Raising a Pull Request.
 If it is raised from a fork then it requires an approval from a maintainer.
 
@@ -72,7 +72,7 @@ Subsequent pushes would be faster (~25 mins) depending on the number of chunks m
 
 We have two Release workflows:
 
-1. **[Build from Main](.github/workflows/push-main.yml)** - On push to the default branch `master` release datetimestamp tagged images to dockerhub. Does **NOT** update the `latest` tag
+1. **[Build from Main](.github/workflows/push-main.yml)** - On push to the default branch `main` release datetimestamp tagged images to dockerhub. Does **NOT** update the `latest` tag
 1. **[Update latest tags](.github/workflows/dockerhub-release.yml)** - Weekly update the `latest` tag of all images in dockerhub with current latest datetimestamp image
 
 We do not release any images from pull requests.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update default branch name to `main`. Actual branch name has already been renamed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/643

## How to test
<!-- Provide steps to test this PR -->
Workflow changes can only be tested post merge to the main branch

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
