### PR TITLE
Allow building specific chunks locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dazzle
 /legacy
+/.dazzle.yaml.orig
+/.dazzle.yaml.temp

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,4 +6,4 @@ ENV BUILDKIT_VERSION=0.9.3
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 # Install custom tools, runtime, etc.
-RUN sudo su -c "cd /usr; curl -L https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar xvz"
+RUN sudo su -c "cd /usr; curl -L https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar xvz" && sudo pip3 install yq

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,8 @@ tasks:
     command: |
       gp await-port 5000
       REPO=localhost:5000/dazzle
-      echo "To build chunks and combinations 'time ./dazzle-up.sh'"
+      echo "To build specific chunks and combinations 'time ./dazzle-up.sh  -c chunk1 -c chunk2 -n combo'"
+      echo "To build all the chunks and combinations 'time ./dazzle-up.sh'"
       echo "To list image chunks 'dazzle project image-name $REPO'"
       echo "To list hashes for image chunks 'dazzle project hash $REPO'"
       echo "To print the combined image maniest 'dazzle project manifest $REPO'"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,7 @@ Here is a list of dependencies and tools:
 
 ## Locally
 
-We ship a shell script [dazzle-up.sh](dazzle-up.sh) that can be used to build the images locally. Run it in a shell:
-
-```bash
-./dazzle-up.sh
-```
+We ship a shell script [dazzle-up.sh](dazzle-up.sh) that can be used to build the images locally. See the following sub sections for usage.
 
 This script will first build the chunks and run tests followed by creation of container images. It uses `dazzle` to perform these tasks.
 
@@ -45,7 +41,25 @@ The images will be pushed to the local registry server running on port 5000. You
 docker pull localhost:5000/dazzle:combo
 ```
 
-where `combo` is the name of the combination defined in [dazzle.yaml](dazzle.yaml) e.g. `full`, clojure, postgresql.
+where `combo` is the name of the combination defined in [dazzle.yaml](dazzle.yaml) e.g. `full`, `clojure`, `postgresql`.
+
+### Build Specific Chunks
+
+Often, you would want to test only the chunks that you modify. You can do that by using the `-c` flag.
+
+```console
+./dazzle-up.sh -c lang-c -c dep-cacert-update -n mychangecombo
+```
+
+Above command will build only chunks `lang-c` and `dep-cacert-update` and combine the created chunks (all variants, if any exists) as a combination with name `mychangecombo`.
+
+### Build All Chunks
+
+Execute the following command to build using the default config `dazzle.yaml` shipped in this repo:
+
+```bash
+./dazzle-up.sh
+```
 
 > **NOTE:** Building images locally consumes a lot of resources and is often slow.
 It might take 1.25 hours to build the images locally.

--- a/dazzle-up.sh
+++ b/dazzle-up.sh
@@ -1,10 +1,96 @@
 #!/bin/bash
 set -euo pipefail
+set +x
 
-REPO=localhost:5000/dazzle
-# First, build chunks without hashes
-dazzle build $REPO -v --chunked-without-hash
-# Second, build again, but with hashes
-dazzle build $REPO -v
-# Third, create combinations of chunks
-dazzle combine $REPO --all -v
+readonly BACKUP_FILE=".dazzle.yaml.orig"
+readonly TEMP_FILE=".dazzle.yaml.temp"
+readonly ORIGINAL_FILE="dazzle.yaml"
+readonly AVAILABLE_CHUNKS=$(ls chunks/)
+readonly REPO="localhost:5000/dazzle"
+
+function usage() {
+	cat <<EOF
+Usage: dazzle-up.sh [OPTION]...
+Options for build:
+  -h, --help      Display this help
+  -c, --chunk     Chunk to build, You can build multiple chunks: -c chunk1 -c chunk2
+  -n, --name      Combination name
+EOF
+}
+
+function build_all() {
+	# # First, build chunks without hashes
+	dazzle build $REPO -v --chunked-without-hash
+	# # Second, build again, but with hashes
+	dazzle build $REPO -v
+	# # Third, create combinations of chunks
+	dazzle combine $REPO --all -v
+
+}
+
+ARGS=$(getopt -o h,:c:n: --long help:,chunk:,name: -- "$@")
+eval set -- "${ARGS}"
+
+[ ! -f ${BACKUP_FILE} ] && echo "Creating a backup of dazzle.yaml as it does not exist yet..." && cp ${ORIGINAL_FILE} ${BACKUP_FILE}
+
+CHUNKS=""
+COMBINATION="default"
+
+while true; do
+	case "$1" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-c | --chunk)
+		# if CHUNKS is empty then assign current value
+		if [[ -z "${CHUNKS}" ]]; then
+			CHUNKS="$2"
+		else
+			# else append
+			CHUNKS+=("$2")
+		fi
+		shift 2
+		;;
+	-n | --name)
+		COMBINATION="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		echo Error: unknown flag "$1"
+		echo "Run 'dazzle-up.sh --help' for usage."
+		exit 1
+		;;
+	esac
+done
+
+# branch off to default dazzle config build for all combination
+[ -z "${CHUNKS}" ] && echo "no chunks specified, will build using the existing ${ORIGINAL_FILE}" && build_all && exit 0
+
+# else build for supplied arguments
+
+[ -f ${ORIGINAL_FILE} ] && echo "Deleting ${ORIGINAL_FILE}" && rm ${ORIGINAL_FILE}
+
+for CN in ${AVAILABLE_CHUNKS}; do
+	if [[ ! ${CHUNKS[@]} =~ ${CN} ]]; then
+		dazzle project ignore ${CN}
+	else
+		VARIANTS=extract_variants
+		for VARIANT in ${VARIANTS}; do
+			CHUNKS_TO_COMBINE+=("${VARIANT}")
+		done
+	fi
+done
+
+dazzle project add-combination ${COMBINATION} "${CHUNKS_TO_COMBINE[@]}"
+
+echo "Saving temperory generated dazzle config in ${TEMP_FILE}"
+cp ${ORIGINAL_FILE} ${TEMP_FILE}
+
+# add logic to handle sigterm ctrl+c
+echo "Copying backup file to original location"
+cp ${BACKUP_FILE} ${ORIGINAL_FILE}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update `dazzle.yaml` to take inputs from user to build chunks and create a combination.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/763

## How to test
<!-- Provide steps to test this PR -->
Run `.dazzle-up.sh`, you should see that all the chunks are built and all the combinations as specified in `dazzle.yaml` are built.

To build specific chunks and combine those chunks use something like this:
```console
./dazzle-up.sh  -c chunk1 -c chunk2 -n combo
``` 

a working example:

```console
./dazzle-up.sh  -c lang-c -c dep-cacert-update -n mychangecombo
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
