### PR TITLE
fix(lang-rust): Custom dockerfile issue for cargo-install to non-existent /workspace dir

### DIFF
--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -18,17 +18,12 @@ RUN cp $HOME/.profile $HOME/.profile_orig \
     && rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
     && rustup completions bash cargo | sudo tee /etc/bash_completion.d/rustup.cargo-bash-completion > /dev/null \
     && printf '%s\n' "$(grep -v -F -x -f $HOME/.profile_orig $HOME/.profile)" \
-                        'mkdir -m 0755 -p "${CARGO_HOME:-/workspace/.cargo}" 2>/dev/null' > $HOME/.bashrc.d/80-rust \
+                        'mkdir -m 0755 -p "${CARGO_HOME:-/workspace/.cargo}" 2>/dev/null' \
+                        'export CARGO_HOME=/workspace/.cargo' \
+                        'export PATH=$CARGO_HOME/bin:$PATH' > $HOME/.bashrc.d/80-rust \
     && _rustup_path="$(command -v rustup)" && mv "$_rustup_path" "${_rustup_path}.main" \
     && printf '%s\n' '#!/usr/bin/bash -eu' \
                         'exec env -u CARGO_HOME "$(command -v rustup.main)" "$@"' > "$_rustup_path" \
-    && chmod 0755 "$_rustup_path"
+    && chmod 0755 "$_rustup_path" && rm $HOME/.profile_orig
 
 RUN cargo install cargo-watch cargo-edit cargo-workspaces
-ENV CARGO_HOME=/workspace/.cargo
-ENV PATH=$CARGO_HOME/bin:$PATH
-
-RUN sudo mkdir -p $CARGO_HOME \
-    && sudo chown -R gitpod:gitpod $CARGO_HOME
-
-RUN bash -lc "cargo install cargo-watch cargo-edit cargo-tree cargo-workspaces"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
CARGO specific env var modifications are now done inside workspace-session but not for docker env.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [this on discord](https://canary.discord.com/channels/816244985187008514/946731644465852466/946805048116121640)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
