### PR TITLE
Update dazzle to v0.1.8

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.7/dazzle_0.1.7_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.8/dazzle_0.1.8_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🏗️ Setup buildkit
         run: |

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.7/dazzle_0.1.7_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.8/dazzle_0.1.8_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🔆 Install skopeo
         run: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,7 @@ tasks:
     openMode: split-right
   - name: dazzle build and test
     before: |
-      curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.7/dazzle_0.1.7_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+      curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.8/dazzle_0.1.8_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
     command: |
       gp await-port 5000
       REPO=localhost:5000/dazzle


### PR DESCRIPTION
## Description
Bump dazzle from v0.1.7 to v0.1.8

## Related Issue(s)
Partial fix for #763

## How to test
- Add variant chunk to ignore section of dazzle.yaml
- Variant chunk should be excluded from build by dazzle

## Release Notes
```release-note
Bump dazzle from v0.1.7 to v0.1.8
```