### PR TITLE
Fix test that gets stuck

### DIFF
--- a/chunks/lang-java/Dockerfile
+++ b/chunks/lang-java/Dockerfile
@@ -10,6 +10,7 @@ ENV TRIGGER_REBUILD=1
 
 RUN curl -fsSL "https://get.sdkman.io" | bash \
  && bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
+             && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /home/gitpod/.sdkman/etc/config \
              && sdk install java ${JAVA_VERSION}.fx-zulu \
              && sdk install gradle \
              && sdk install maven \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix test that gets stuck during build.

The `lang-java.yaml` test :
```yaml
- desc: it should run sdk
  command: [sdk v]
  entrypoint: [bash, -i, -c]
  assert:
  - status == 0
  - stdout.indexOf("SDKMAN") != -1
```

gets stuck because the `sdk v` produces an interactive shell asking user to upgrade the sdkman version. 
```console
gitpod ~ $ sdk v
==== BROADCAST =================================================================
* 2022-03-10: grails 5.1.3 available on SDKMAN!
* 2022-03-10: doctoolchain 2.0.5 available on SDKMAN! https://doctoolchain.github.io/docToolchain/v2.0.x/030_news/2022/2.0.5-release.html
* 2022-03-10: jbang 0.91.0 available on SDKMAN! https://github.com/jbangdev/jbang/releases/tag/v0.91.0
================================================================================

SDKMAN 5.13.2


ATTENTION: A new version of SDKMAN is available...

The current version is 5.14.1, but you have 5.13.2.

Would you like to upgrade now? (Y/n): 
```

This prompt shell can be disabled by configuring `sdkman` by setting `sdkman_selfupdate_enable=false`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/767

## How to test
<!-- Provide steps to test this PR -->
NA

## How to verify this was the problem

If you run the existing java image and try running `sdk v` inside the container you will get stuck in the prompt shell.
Update the variable using `sed` and rerun the command and you should not see prompt shell anymore.


```console
gitpod /workspace/workspace-images (princerachit/builds-are-failing-767) $ docker run -it gitpod/workspace-java-11
gitpod ~ $ sdk v
==== BROADCAST =================================================================
* 2022-03-10: grails 5.1.3 available on SDKMAN!
* 2022-03-10: doctoolchain 2.0.5 available on SDKMAN! https://doctoolchain.github.io/docToolchain/v2.0.x/030_news/2022/2.0.5-release.html
* 2022-03-10: jbang 0.91.0 available on SDKMAN! https://github.com/jbangdev/jbang/releases/tag/v0.91.0
================================================================================

SDKMAN 5.13.2


ATTENTION: A new version of SDKMAN is available...

The current version is 5.14.1, but you have 5.13.2.

Would you like to upgrade now? (Y/n): ^C
gitpod ~ $ sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /home/gitpod/.sdkman/etc/config
gitpod ~ $ sdk v

SDKMAN 5.13.2
gitpod ~ $ 
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
