### PR TITLE
Run push-main w/o env approval

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -14,7 +14,6 @@ jobs:
   # Check the "Required reviewers" box and enter at least one user or team name.
   sync:
     runs-on: ubuntu-latest
-    environment: "production"
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
## Is your feature request related to a problem? Please describe
<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
No

## Describe the behaviour you'd like
<!-- A clear and concise description of what you want to happen. -->
This will push timestamped images to Docker Hub sooner for users.

## Describe alternatives you've considered
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Continue waiting for approval from the workspace team, which incurs a delay.

## Additional context
<!-- Add any other context or screenshots about the feature request here. -->
None. We'll continue requiring approval to tag images as latest on Docker Hub (we want to time that with building of our packer image so we can cache images).