### PR TITLE
[feat] add lang-elixir workspace chunk and image

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -7,6 +7,7 @@
     workspace-base: "20.*"
     workspace-c: "20.*"
     workspace-clojure: "20.*"
+    workspace-elixir: "20.*"
     workspace-full: "20.*"
     workspace-full-vnc: "20.*"
     workspace-go: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -4,6 +4,7 @@ sync:
     - base
     - c
     - clojure
+    - elixir
     - full
     - full-vnc
     - go

--- a/chunks/lang-elixir/Dockerfile
+++ b/chunks/lang-elixir/Dockerfile
@@ -1,0 +1,15 @@
+ARG base
+FROM ${base}
+
+USER root
+
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_REBUILD=1
+
+RUN curl -fsSL https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | sudo gpg --dearmor -o /usr/share/keyrings/erlang_solutions.gpg.key \
+    && echo "deb [signed-by=/usr/share/keyrings/erlang_solutions.gpg.key] https://packages.erlang-solutions.com/ubuntu focal contrib" | sudo tee /etc/apt/sources.list.d/erlang.list > /dev/null \
+    && apt update \
+    && install-packages \
+        elixir
+
+USER gitpod

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -15,6 +15,11 @@ combiner:
       - base
       chunks:
         - lang-clojure
+    - name: elixir
+      ref:
+      - base
+      chunks:
+        - lang-elixir
     - name: full
       ref:
       - base
@@ -107,11 +112,6 @@ combiner:
       - full
       chunks:
         - tool-yugabytedb
-    - name: elixir
-      ref:
-      - base
-      chunks:
-        - lang-elixir
   envvars:
     - name: PATH
       action: merge-unique

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -107,6 +107,11 @@ combiner:
       - full
       chunks:
         - tool-yugabytedb
+    - name: elixir
+      ref:
+      - base
+      chunks:
+        - lang-elixir
   envvars:
     - name: PATH
       action: merge-unique

--- a/tests/lang-elixir.yaml
+++ b/tests/lang-elixir.yaml
@@ -1,0 +1,6 @@
+- desc: it should run elixir
+  command: [elixir,--version]
+  assert:
+  - status == 0
+  - stdout.indexOf("Erlang/OTP 24") != -1 ||
+    stdout.indexOf("Elixir 1.13.0") != -1


### PR DESCRIPTION
## Description
Create new `workspace-elixir` image for elixir based gitpod projects. This is to add a new chunk, and make a standalone `workspace-elixir` image based off `workspace-base`. There is no intent to add this to `workspace-full`
## Related Issue(s)
Implements #775 

## How to test
Tests included in tests/lang-elixir.yaml (version output testing, latest elixir from https://www.erlang-solutions.com/downloads/)
## Release Notes
```
add workspace-elixir image
```
## Documentation
This adds a standard elixir and erlang toolchain workspace to the available gitpod workspace images for quicker bootstrapping of existing projects.