### PR TITLE
Use dedicated environment for dockerhub-release.yml workflow

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -11,7 +11,7 @@ jobs:
   # Check the "Required reviewers" box and enter at least one user or team name.
   promote-latest:
     runs-on: ubuntu-latest
-    environment: "production"
+    environment: "production-restricted"
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -14,6 +14,7 @@ jobs:
   # Check the "Required reviewers" box and enter at least one user or team name.
   sync:
     runs-on: ubuntu-latest
+    environment: "production"
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. Revert previous commit which removed env from push-main.yml
2. Update dockerhub-release.yml workflow env



The env `production-restricted` is newly created and hosts the same credentials of Dockerhub.
It always require manual approval.

The existing env `production` is updated to remove manual approval.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes NA

## How to test
<!-- Provide steps to test this PR -->
Merging this PR should auto run build from main without approval/

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
