### PR TITLE
Upgrade to dazzle 0.1.10

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.8/dazzle_0.1.8_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.10/dazzle_0.1.10_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🏗️ Setup buildkit
         run: |

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.8/dazzle_0.1.8_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.10/dazzle_0.1.10_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🔆 Install skopeo
         run: |

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,7 +9,7 @@ USER root
 
 # Install dazzle, buildkit and pre-commit
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr \
-    && curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.8/dazzle_0.1.8_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin \
+    && curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.10/dazzle_0.1.10_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin \
     && curl -sSL https://github.com/mvdan/sh/releases/download/v3.4.2/shfmt_v3.4.2_linux_amd64 -o /usr/bin/shfmt \
     && chmod +x /usr/bin/shfmt \
     && install-packages shellcheck \


### PR DESCRIPTION
## Description

Update to support latest dazzle, includes:
https://github.com/gitpod-io/dazzle/releases/tag/v0.1.9
https://github.com/gitpod-io/dazzle/releases/tag/v0.1.10

## How to test

1. The PR actions must pass (which builds, pushes, and pulls image from an in-memory registry)
2. After a merge to main, we must be able to use the timestamped images with Gitpod
