### PR TITLE
fix: /usr/games missing PATH entry

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -58,3 +58,6 @@ RUN sudo echo "Running 'sudo' for Gitpod: success" && \
 
 # configure git-lfs
 RUN sudo git lfs install --system
+
+# Custom PATH additions
+ENV PATH=/usr/games:$PATH


### PR DESCRIPTION
## Description
Packages like [`cowsay`](https://packages.ubuntu.com/bionic/all/cowsay/filelist) get installed at `/usr/games` but it's not on PATH. Although I'm not sure if what I did on this PR is the recommended approach, please suggest.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://app.frontapp.com/open/cnv_ix5jz62

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
/usr/games is now added on PATH for packages like cowsay
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
