### PR TITLE
An optional preload flag to control the YugabyteDB initialization

### DIFF
--- a/chunks/tool-yugabytedb/Dockerfile
+++ b/chunks/tool-yugabytedb/Dockerfile
@@ -38,7 +38,7 @@ ENV YCQL_API_PORT=12000
 
 # re-initialization is automatically handled
 RUN echo "\n# yugabytedb start command" >> /home/gitpod/.bashrc.d/100-yugabyedb-launch
-RUN echo "yugabyted start --base_dir=$STORE --listen=$HOST" >> /home/gitpod/.bashrc.d/100-yugabyedb-launch
+RUN echo "[[ -f \${GITPOD_REPO_ROOT}/.nopreload ]] || yugabyted start --base_dir=$STORE --listen=$HOST > /dev/null" >> /home/gitpod/.bashrc.d/100-yugabyedb-launch
 
 RUN chmod +x /home/gitpod/.bashrc.d/100-yugabyedb-launch
 


### PR DESCRIPTION
Signed-off-by: Srinivasa Vasu <srinivasan.surprise@gmail.com>

## Description
An optional `.nopreload` file as part of the repo restricts the workspace from installation & config of the DB. By default, when the workspace launches, DB will be initialized and running. This optional file gives the flexibility to control the initialization behavior. With the `.nopreload` file, users can control the DB via the .gitpod.yml file.