### PR TITLE
Log in again to extend GAR access_token

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -131,6 +131,18 @@ jobs:
         run: |
           sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} https://${{ env.DH_IMAGE_REGISTRY }}
 
+      - name: 🔐 Authenticate to Google Cloud again
+        id: "auth"
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
+          service_account: ${{env.IAM_SERVICE_ACCOUNT}}
+
+      - name: ✍🏽 Login to GAR using skopeo again
+        run: |
+          sudo skopeo login -u oauth2accesstoken --password=${{ steps.auth.outputs.access_token }} https://${{env.GAR_IMAGE_REGISTRY}}
+
       - name: 🐳 Sync images with specific tags to Docker Hub
         run: |
             sudo skopeo sync \


### PR DESCRIPTION
Will fix the token timeout on skopeo sync at the end of our push-main flow.

Ref: https://github.com/gitpod-io/workspace-images/runs/5756757882?check_suite_focus=true