### PR TITLE
Use a unique ID to authenticate with Google again

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -132,7 +132,7 @@ jobs:
           sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} https://${{ env.DH_IMAGE_REGISTRY }}
 
       - name: 🔐 Authenticate to Google Cloud again
-        id: "auth"
+        id: "auth_again"
         uses: google-github-actions/auth@v0.6.0
         with:
           token_format: "access_token"
@@ -141,7 +141,7 @@ jobs:
 
       - name: ✍🏽 Login to GAR using skopeo again
         run: |
-          sudo skopeo login -u oauth2accesstoken --password=${{ steps.auth.outputs.access_token }} https://${{env.GAR_IMAGE_REGISTRY}}
+          sudo skopeo login -u oauth2accesstoken --password=${{ steps.auth_again.outputs.access_token }} https://${{env.GAR_IMAGE_REGISTRY}}
 
       - name: 🐳 Sync images with specific tags to Docker Hub
         run: |


### PR DESCRIPTION
The previous PR had a linter error. I've given the authN again step a unique ID, and leveraged it accordingly in the following step to log into GAR with skopeo.