### PR TITLE
Add node fixer

### DIFF
--- a/.autofix/fixers/update-lang-node.js
+++ b/.autofix/fixers/update-lang-node.js
@@ -1,0 +1,31 @@
+const os = require('os');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+exports.register = async (fixers) => {
+  const { stdout, stderr } = await exec('bash -lc ". ~/.nvm/nvm.sh && nvm ls-remote --no-colors"');
+  if (stderr) {
+    throw stderr;
+  }
+
+  const minorVersionReplacements = {};
+  for (const line of stdout.split('\n')) {
+    const match = line.trim().match(/^[->]*\s*([a-z1-9\.]+-)?v(\d+\.)(\d+\.\d+)\s*.*$/);
+    if (!match || match[2] === '0.') {
+      // Unsupported format, or unsupported version (e.g. Node.js v0).
+      continue;
+    }
+
+    const prefix = match[1] ? match[1] + 'v' : '';
+    const pattern = (prefix + match[2]).replace(/\./g, '\\.') + '[0-9][0-9]*\\.[0-9][0-9]*';
+    minorVersionReplacements[pattern] = prefix + match[2] + match[3];
+  }
+
+  fixers[0].push({
+    id: 'upgrade-lang-node',
+    cmd: Object.keys(minorVersionReplacements).map(pattern => {
+        return `sed ${os.type() === 'Darwin' ? '-i "" -E' : '-i -e'} "s/\\(NODE_VERSION.*\\)${pattern}/\\1${minorVersionReplacements[pattern]}/g" chunks/lang-node/chunk.yaml`;
+      }).join('\n'),
+    description: 'update lang-node',
+  });
+}

--- a/.autofix/fixers/update-lang-python.js
+++ b/.autofix/fixers/update-lang-python.js
@@ -24,6 +24,6 @@ exports.register = async (fixers) => {
     cmd: Object.keys(patchVersionReplacements).map(pattern => {
         return `sed ${os.type() === 'Darwin' ? '-i "" -E' : '-i -e'} "s/\\(PYTHON_VERSION.*\\)${pattern}/\\1${patchVersionReplacements[pattern]}/g" chunks/lang-python/chunk.yaml`;
     }).join('\n'),
-    description: 'Update Python variants',
+    description: 'update lang python',
   });
 };

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
   - name: "16.13.2"
     args:
-      NODE_VERSION: 16.13.2
+      NODE_VERSION: 16.14.2
   - name: "17.4.0"
     args:
-      NODE_VERSION: 17.4.0
+      NODE_VERSION: 17.8.0

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
-  - name: "16.13.2"
+  - name: "16"
     args:
       NODE_VERSION: 16.14.2
-  - name: "17.4.0"
+  - name: "17"
     args:
       NODE_VERSION: 17.8.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -28,7 +28,7 @@ combiner:
         - lang-clojure
         - lang-go:1.18.0
         - lang-java:11
-        - lang-node:16.13.2
+        - lang-node:16
         - lang-python:3.8
         - lang-ruby:2.7
         - lang-rust
@@ -49,13 +49,13 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:17.4.0
+        - lang-node:17
         - tool-chrome
     - name: node-lts
       ref:
       - base
       chunks:
-        - lang-node:16.13.2
+        - lang-node:16
         - tool-chrome
     - name: python
       ref:

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -3,8 +3,8 @@
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("v16.13.2") != -1 ||
-    stdout.indexOf("v17.4.0")  != -1
+  - stdout.indexOf("v16") != -1 ||
+    stdout.indexOf("v17")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
## Description
Adds a fixer that updates node versions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially fixes #661

## How to test
- Open workspace
- Clone autofix from https://github.com/autofix-dev/autofix into e.g /workspace/autofix & npm install
- Change node versions in chunk.yaml to older versions
- Start autofix with npx autofix
- -> Node versions should have been updated

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```