### PR TITLE
Add neovim to base image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ You need to have a gitpod account in order to seamlessly contribute to this repo
 
 ## Tools
 
-This repo is already configured with a [.gitpod.yml](.gitpod.yml) which installs and sets up all the required dependency.
+This repo is already configured with a [.gitpod.yml](.gitpod.yml) which installs and sets up all the required dependencies.
 It also starts the services that are required to build this repo in dedicated bash shells.
 
 Here is a list of dependencies and tools:

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -27,6 +27,7 @@ RUN yes | unminimize \
         ssl-cert \
         fish \
         zsh \
+        tmux \
     && locale-gen en_US.UTF-8
 
 ENV LANG=en_US.UTF-8

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -38,6 +38,10 @@ RUN upgrade-packages
 RUN add-apt-repository -y ppa:git-core/ppa \
     && install-packages git git-lfs
 
+### neovim ###
+RUN sudo add-apt-repository -y ppa:neovim-ppa/stable \
+  && install-packages neovim
+
 ### Gitpod user ###
 # '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -28,6 +28,7 @@ RUN yes | unminimize \
         fish \
         zsh \
         tmux \
+        fzf \
     && locale-gen en_US.UTF-8
 
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
## Description

Add [Neovim](https://neovim.io/) to the base image, along with [tmux](https://github.com/tmux/tmux/wiki) and [fzf](https://github.com/junegunn/fzf).

Gitpod currently provides a basic user experience for users who work by SSHing into a workspace. For users who want a better experience, the only option currently is to install extra tools via their `dotfiles` repo. However this makes workspace startup times unacceptably slow. By adding more tools commonly used by CLI-centric dev workflows to the base image we enable these users to get more out of Gitpod.

## Related Issue(s)

## How to test

```
./build-combo.sh full
docker pull localhost:5000/dazzle:full
docker run --rm -it localhost:5000/dazzle:full /bin/bash
$ nvim --version
$ tmux -V
$ fzf --version
```

## Release Notes

```release-note
Add `nvim`, `tmux` and `fzf` to the base image for all workspaces
```

## Documentation

No changes required.
