### PR TITLE
Update dazzle and buildkit

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.10/dazzle_0.1.10_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.11/dazzle_0.1.11_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.0/buildkit-v0.10.0.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.1/buildkit-v0.10.1.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.10/dazzle_0.1.10_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.11/dazzle_0.1.11_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🔆 Install skopeo
         run: |
@@ -56,7 +56,7 @@ jobs:
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.0/buildkit-v0.10.0.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.1/buildkit-v0.10.1.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,14 +2,14 @@ FROM gitpod/workspace-full
 
 ENV RETRIGGER=1
 
-ENV BUILDKIT_VERSION=0.10.0
+ENV BUILDKIT_VERSION=0.10.1
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 USER root
 
 # Install dazzle, buildkit and pre-commit
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr \
-    && curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.10/dazzle_0.1.10_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin \
+    && curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.11/dazzle_0.1.11_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin \
     && curl -sSL https://github.com/mvdan/sh/releases/download/v3.4.2/shfmt_v3.4.2_linux_amd64 -o /usr/bin/shfmt \
     && chmod +x /usr/bin/shfmt \
     && install-packages shellcheck \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update dazzle and buildkit
* dazzle to 0.1.11
* buildkit to 0.10.1

The build in main is timing out...

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a ... maybe the build timing out in main

## How to test
<!-- Provide steps to test this PR -->
1. Once dazzle 0.1.11 is ready, proceed with
2. Open this PR in Gitpod, to assert the image builds successfully
3. Flip this to ready for review, and let the built-in tests run.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update dazzle to 0.1.11 and buildkit to 0.10.1
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
