### PR TITLE
Disable sdkman self update feature using new flag

### DIFF
--- a/chunks/lang-java/Dockerfile
+++ b/chunks/lang-java/Dockerfile
@@ -11,6 +11,7 @@ ENV TRIGGER_REBUILD=1
 RUN curl -fsSL "https://get.sdkman.io" | bash \
  && bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
              && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /home/gitpod/.sdkman/etc/config \
+             && sed -i 's/sdkman_selfupdate_feature=true/sdkman_selfupdate_feature=false/g' /home/gitpod/.sdkman/etc/config \
              && sdk install java ${JAVA_VERSION}.fx-zulu \
              && sdk install gradle \
              && sdk install maven \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
sdkman uses a new flag to control self update. This PR updates that flag to the sdkman config in order to avoid asking user if they want to update the sdkman version. This as a result also fixes failing main branch builds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
NA

## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
