### PR TITLE
update version of docker compose

### DIFF
--- a/chunks/tool-docker/Dockerfile
+++ b/chunks/tool-docker/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor
 RUN curl -o /usr/bin/slirp4netns -fsSL https://github.com/rootless-containers/slirp4netns/releases/download/v1.1.12/slirp4netns-$(uname -m) \
     && chmod +x /usr/bin/slirp4netns
 
-RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-$(uname -m) \
+RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.4.1/docker-compose-linux-$(uname -m) \
     && chmod +x /usr/local/bin/docker-compose && mkdir -p /usr/local/lib/docker/cli-plugins && \
     ln -s /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
 

--- a/tests/tool-docker.yaml
+++ b/tests/tool-docker.yaml
@@ -8,7 +8,7 @@
   command: [docker-compose --version]
   assert:
   - status == 0
-  - stdout.indexOf("2.2.3") != -1
+  - stdout.indexOf("2.4.1") != -1
 - desc: containerd should be installed
   command: [containerd, config, dump]
   assert:


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->
docker compose v2.2.3 has several bugs that have been fixed in newer versions. The latest version at the moment is 2.4.1.

## Related Issue(s)
Related to https://github.com/gitpod-io/workspace-images/issues/577

## How to test
<!-- Provide steps to test this PR -->
Run a workspace and check `docker compose version` to see that it's v2.4.1.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
