### PR TITLE
refactor(lang-rust): Optimize the image and fix `rustup toolchain install` issue

### DIFF
--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -7,23 +7,16 @@ USER gitpod
 ENV TRIGGER_REBUILD=1
 
 ENV PATH=$HOME/.cargo/bin:$PATH
-RUN cp $HOME/.profile $HOME/.profile_orig \
-    && curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.60.0 \
-    && rustup component add \
-        rls \
-        rust-analysis \
-        rust-src \
-        rustfmt \
-        clippy \
+
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path --default-toolchain stable \
+        -c rls rust-analysis rust-src rustfmt clippy \
     && rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
     && rustup completions bash cargo | sudo tee /etc/bash_completion.d/rustup.cargo-bash-completion > /dev/null \
-    && printf '%s\n' "$(grep -v -F -x -f $HOME/.profile_orig $HOME/.profile)" \
-                        'mkdir -m 0755 -p "${CARGO_HOME:-/workspace/.cargo}" 2>/dev/null' \
-                        'export CARGO_HOME=/workspace/.cargo' \
+    && printf '%s\n'    'export CARGO_HOME=/workspace/.cargo' \
+                        'mkdir -m 0755 -p "$CARGO_HOME" 2>/dev/null' \
                         'export PATH=$CARGO_HOME/bin:$PATH' > $HOME/.bashrc.d/80-rust \
-    && _rustup_path="$(command -v rustup)" && mv "$_rustup_path" "${_rustup_path}.main" \
-    && printf '%s\n' '#!/usr/bin/bash -eu' \
-                        'exec env -u CARGO_HOME "$(command -v rustup.main)" "$@"' > "$_rustup_path" \
-    && chmod 0755 "$_rustup_path" && rm $HOME/.profile_orig
+    && _rustup_path="$(which rustup)" && mv "$_rustup_path" "${_rustup_path}.main" \
+    && cargo install cargo-watch cargo-edit cargo-workspaces \
+    && rm -r "${_rustup_path%/*/*}/registry" # This registry cache is now useless as we change the CARGO_HOME path to `/workspace`
 
-RUN cargo install cargo-watch cargo-edit cargo-workspaces
+COPY --chown=gitpod:gitpod rustup $HOME/.cargo/bin

--- a/chunks/lang-rust/rustup
+++ b/chunks/lang-rust/rustup
@@ -1,0 +1,19 @@
+#!/usr/bin/bash -eu
+
+function main() {
+	# local _self _orig_rustup;
+	_self="$(readlink -f "$0")"
+	_orig_rustup="$(command -v rustup.main)"
+
+	function revert() {
+		mv "$_self" "$_orig_rustup"
+		printf '%s\n' "$(declare -f main)" 'main "$@"' >"$_self"
+		chmod 0755 "$_self"
+	}
+
+	mv "$_orig_rustup" "$_self"
+	trap revert ERR INT
+	unset CARGO_HOME && { "$_self" "$@" || :; }
+	revert
+}
+main "$@"

--- a/tests/lang-rust.yaml
+++ b/tests/lang-rust.yaml
@@ -4,8 +4,10 @@
   assert:
   - status == 0
   - stdout.indexOf("rustc") != -1
-- desc: it should have properly configured rustup
-  command: [rustup show]
+- desc: it should have properly functioning rustup
+  command: [
+      rustup show && rustup update && rustup toolchain install nightly && cargo new /tmp/foo,
+    ] # Testing out `cargo` at the end is necessary to assert that rustup isn't messing things up
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`rustup toolchain install <toolchain>` command was conflicting with the wrapper script of it.
Also, some tiny optimizations was done. Now this image consumes `214MB` less space as we get rid of the unnecessary `$HOME/.cargo/registry` 🥳

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #[this-on-discord](https://discord.com/channels/816244985187008514/966633482619084800/966633485156626442), reported by @jcornaz

## How to test
<!-- Provide steps to test this PR -->
- Run a docker container of the `lang-rust`(workspace-rust) chunk.
- Run `rustup toolchain install stable nightly`
- Run `cargo new /tmp/foo` to check cargo is properly functioning.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
