### PR TITLE
[tailscale] Fix tailscale chunk

### DIFF
--- a/chunks/tool-tailscale/Dockerfile
+++ b/chunks/tool-tailscale/Dockerfile
@@ -9,6 +9,10 @@ ENV TRIGGER_REBUILD=1
 RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key add - \
     && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
     && apt-get update \
-    && apt-get install -y tailscale
+    && apt-get install -y tailscale \
+    && rm /etc/apt/sources.list.d/tailscale.list
+
+## "apt-key add" adds a PGP to a joint file which does not make it through dazzle.
+## If we didn't remove the source list entry above, subsequent apt-get operations would break.
 
 USER gitpod

--- a/tests/lang-rust.yaml
+++ b/tests/lang-rust.yaml
@@ -19,22 +19,26 @@
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("cargo") != -1
+  - stdout.indexOf("cargo") != -1 ||
+    stderr.indexOf("cargo") != -1
 - desc: it should have watch subcommand for cargo
   entrypoint: [bash, -i, -c]
   command: [cargo watch --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo-watch") != -1
+  - stdout.indexOf("cargo-watch") != -1 ||
+    stderr.indexOf("cargo-watch") != -1
 - desc: it should have one of edit(add, rm, upgrade, set-version) subcommand(s) for cargo
   entrypoint: [bash, -i, -c]
   command: [cargo add --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo-add") != -1
+  - stdout.indexOf("cargo-add") != -1 ||
+    stderr.indexOf("cargo-add") != -1
 - desc: it should have workspaces subcommand for cargo
   entrypoint: [bash, -i, -c]
   command: [cargo workspaces --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo-workspaces") != -1
+  - stdout.indexOf("cargo-workspaces") != -1 ||
+    stderr.indexOf("cargo-workspaces") != -1


### PR DESCRIPTION
## Description
Adding PGP keys to apt does not work with dazzle.
This change removes the the source list to avoid this problem in subsequent `apt-get` operations.
