### PR TITLE
Update non-LTS node from 17 to 18

### DIFF
--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -2,6 +2,6 @@ variants:
   - name: "16"
     args:
       NODE_VERSION: 16.14.2
-  - name: "17"
+  - name: "18"
     args:
-      NODE_VERSION: 17.9.0
+      NODE_VERSION: 18.0.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -54,7 +54,7 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:17
+        - lang-node:18
         - tool-chrome
     - name: node-lts
       ref:

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -4,7 +4,7 @@
   assert:
   - status == 0
   - stdout.indexOf("v16") != -1 ||
-    stdout.indexOf("v17")  != -1
+    stdout.indexOf("v18")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Updates (non-LTS) Node.js from 17 to 18 in `gitpod/workspace-node` image.

https://github.com/nodejs/node/blob/3a6b9759810922130c1389bf67d89d50fc8dd26a/doc/changelogs/CHANGELOG_V18.md#18.0.0

> 2022-04-19, Version 18.0.0 (Current), @BethGriggs

## Related Issue(s)
Fixes #811

## How to test
TBD

## Release Notes
```release-note
Bump node.js to v18.0.0 in gitpod/workspace-node image.
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?

* No
  * Are you sure? If so, nothing to do here.
