### PR TITLE
Update Ubuntu from focal (20.04) to jammy (22.04)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal
+FROM buildpack-deps:jammy
 
 COPY install-packages upgrade-packages /usr/bin/
 

--- a/base/install-packages
+++ b/base/install-packages
@@ -26,7 +26,7 @@ if [[ $EUID != 0 ]]; then
 fi
 
 # Set a runlevel to avoid invoke-rc.d warnings
-# http://manpages.ubuntu.com/manpages/focal/man8/runlevel.8.html#environment
+# http://manpages.ubuntu.com/manpages/jammy/man8/runlevel.8.html#environment
 # shellcheck disable=SC2034
 RUNLEVEL=1
 

--- a/chunks/lang-c/Dockerfile
+++ b/chunks/lang-c/Dockerfile
@@ -7,8 +7,8 @@ USER root
 ENV TRIGGER_REBUILD=1
 
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ \
-    llvm-toolchain-focal main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ \
+    llvm-toolchain-jammy main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
     && apt update \
     && install-packages \
         clang \

--- a/chunks/lang-elixir/Dockerfile
+++ b/chunks/lang-elixir/Dockerfile
@@ -6,10 +6,7 @@ USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=1
 
-RUN curl -fsSL https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | sudo gpg --dearmor -o /usr/share/keyrings/erlang_solutions.gpg.key \
-    && echo "deb [signed-by=/usr/share/keyrings/erlang_solutions.gpg.key] https://packages.erlang-solutions.com/ubuntu focal contrib" | sudo tee /etc/apt/sources.list.d/erlang.list > /dev/null \
-    && apt update \
-    && install-packages \
-        elixir
+# jammy provides Erlang/OTP 24: https://packages.ubuntu.com/jammy/erlang
+RUN install-packages elixir
 
 USER gitpod

--- a/chunks/tool-tailscale/Dockerfile
+++ b/chunks/tool-tailscale/Dockerfile
@@ -6,8 +6,8 @@ USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=1
 
-RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key add - \
-    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
+RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.gpg | sudo apt-key add - \
+    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
     && apt-get update \
     && apt-get install -y tailscale
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Updates Ubuntu from focal (20.04) to jammy (22.04).

## Related Issue(s)
Fixes #810

## How to test
TBD

## Release Notes
```release-note
!Bump ubuntu from 20.04 to 22.04
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment