### PR TITLE
Make dotnet work properly on shiftfs

### DIFF
--- a/chunks/tool-dotnet/Dockerfile
+++ b/chunks/tool-dotnet/Dockerfile
@@ -10,3 +10,14 @@ ENV TRIGGER_REBUILD=1
 RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.200 --install-dir /home/gitpod/dotnet
 ENV DOTNET_ROOT=/home/gitpod/dotnet
 ENV PATH=/home/gitpod/dotnet:$PATH
+
+# TODO(toru): Remove this hack when the kernel bug is resolved.
+#             ref. https://github.com/gitpod-io/gitpod/issues/8901
+RUN bash \
+    && { echo 'if [ ! -z $GITPOD_REPO_ROOT ]; then'; \
+        echo '\tCONTAINER_DIR=$(awk '\''{ print $6 }'\'' /proc/self/maps | grep ^\/run\/containerd | head -n 1 | cut -d '\''/'\'' -f 1-6)'; \
+        echo '\tif [ ! -z $CONTAINER_DIR ]; then'; \
+        echo '\t\t[[ ! -d $CONTAINER_DIR ]] && sudo mkdir -p $CONTAINER_DIR && sudo ln -s / $CONTAINER_DIR/rootfs'; \
+        echo '\tfi'; \
+        echo 'fi'; } >> /home/gitpod/.bashrc.d/110-dotnet
+RUN chmod +x /home/gitpod/.bashrc.d/110-dotnet


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Special workarounds are incorporated into the image for dotnet to work properly.
Detail -> https://github.com/gitpod-io/gitpod/issues/8901#issuecomment-1103434852

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8901

## How to test
<!-- Provide steps to test this PR -->

You can get a script that will run with this command, so run it in a shiftfs and fusefs environment to make sure dotnet is working properly.
```console
$ ./build-combo.sh dotnet
$ docker run localhost:5000/dazzle:dotnet cat /home/gitpod/.bashrc.d/110-dotnet
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make dotnet work properly on shiftfs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No