### PR TITLE
refactor(vnc): Install `x11-xserver-utils` and some optimizations

### DIFF
--- a/chunks/tool-vnc/.Xresources
+++ b/chunks/tool-vnc/.Xresources
@@ -1,9 +1,0 @@
-Xft.dpi: 190
-
-! These might also be useful depending on your monitor and personal preference:
-Xft.autohint: 0
-Xft.lcdfilter:  lcddefault
-Xft.hintstyle:  hintfull
-Xft.hinting: 1
-Xft.antialias: 1
-Xft.rgba: rgb

--- a/chunks/tool-vnc/.xinitrc
+++ b/chunks/tool-vnc/.xinitrc
@@ -4,34 +4,34 @@
 : "${DISPLAY:=":0"}"
 export DISPLAY
 
-# Load resources
-for file in "$HOME/.Xresources" "/etc/X11/Xresources"; do
-	if [ -f "$file" ]; then
-		echo "Loading resource: $file"
-		xrdb -merge "$file"
-	fi
-done
+# # Load resources
+# for file in "$HOME/.Xresources" "/etc/X11/Xresources"; do
+# 	if [ -f "$file" ]; then
+# 		echo "Loading resource: $file"
+# 		xrdb -merge "$file"
+# 	fi
+# done
 
-# Load keymaps
-for file in "$HOME/.Xkbmap" "/etc/X11/Xkbmap"; do
-	if [ -f "$file" ]; then
-		echo "Loading keymap: $file"
-		# shellcheck disable=SC2046
-		setxkbmap $(<"$file")
-		XKB_IN_USE=yes
-	fi
-done
+# # Load keymaps
+# for file in "$HOME/.Xkbmap" "/etc/X11/Xkbmap"; do
+# 	if [ -f "$file" ]; then
+# 		echo "Loading keymap: $file"
+# 		# shellcheck disable=SC2046
+# 		setxkbmap $(<"$file")
+# 		XKB_IN_USE=yes
+# 	fi
+# done
 
-# Load xmodmap if not using XKB
-if [ -z "$XKB_IN_USE" ]; then
-	for file in "$HOME/.Xmodmap" "/etc/X11/Xmodmap"; do
-		if [ -f "$file" ]; then
-			echo "Loading modmap: $file"
-			xmodmap "$file"
-		fi
-	done
-fi
+# # Load xmodmap if not using XKB
+# if [ -z "$XKB_IN_USE" ]; then
+# 	for file in "$HOME/.Xmodmap" "/etc/X11/Xmodmap"; do
+# 		if [ -f "$file" ]; then
+# 			echo "Loading modmap: $file"
+# 			xmodmap "$file"
+# 		fi
+# 	done
+# fi
 
-unset XKB_IN_USE
+# unset XKB_IN_USE
 
 exec dbus-launch --exit-with-session xfce4-session

--- a/chunks/tool-vnc/Dockerfile
+++ b/chunks/tool-vnc/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSL https://download.opensuse.org/repositories/home:/ungoogled_chromiu
   && install-packages xfce4 xfce4-terminal \
   tigervnc-standalone-server tigervnc-xorg-extension \
   dbus dbus-x11 gnome-keyring \
-  tmux ungoogled-chromium xdg-utils \
+  ungoogled-chromium xdg-utils x11-xserver-utils \
   && ln -srf /usr/bin/chromium /usr/bin/google-chrome
 # To make ungoogled_chromium discoverable by tools like flutter
 
@@ -25,10 +25,10 @@ COPY novnc-index.html /opt/novnc/index.html
 # Add VNC startup script
 COPY gp-vncsession /usr/bin/
 RUN chmod 0755 $(which gp-vncsession)
-RUN printf '%s\n' 'export DISPLAY=:0' "test -v GITPOD_REPO_ROOT && gp-vncsession" >> $HOME/.bashrc
+RUN printf '%s\n' 'export DISPLAY=:0' \
+                  'test -v GITPOD_REPO_ROOT && gp-vncsession' >> $HOME/.bashrc
 
 # Add X11 dotfiles
-COPY --chown=gitpod:gitpod .Xresources $HOME/
 COPY --chown=gitpod:gitpod .xinitrc $HOME/
 
 USER gitpod

--- a/chunks/tool-vnc/gp-vncsession
+++ b/chunks/tool-vnc/gp-vncsession
@@ -42,19 +42,19 @@ if test ! -e /tmp/.X0-lock; then {
 	# Start vncserver
 	log::info "Starting tigerVNC server on port $VNC_PORT"
 	vncserver -kill "${DISPLAY}"
-	vncserver -geometry "${TIGERVNC_GEOMETRY:-1920x1080}" -SecurityTypes None $DISPLAY >/dev/null 2>&1
+	{ vncserver -geometry "${TIGERVNC_GEOMETRY:-1920x1080}" -SecurityTypes None $DISPLAY 2>&1; } >/tmp/vncserver.log 2>&1
 
 	# Start web vncclient
 	no_vnc_cmd="bash novnc_proxy --vnc localhost:${VNC_PORT} --listen ${NOVNC_PORT}"
 	if ! pgrep -f "$no_vnc_cmd" 1>/dev/null; then {
 		log::info "Starting noVNC web client on $NOVNC_PORT"
-		tmux new-session -d -s novnc_client \
-			"{ cd /opt/novnc/utils && exec $no_vnc_cmd 2>&1; } > /tmp/novnc.log 2>&1"
+		{ cd /opt/novnc/utils && $no_vnc_cmd 2>&1; } >/tmp/novnc.log 2>&1 &
+		disown
 	}; fi
 
 	# Wait
 	log::info "Waiting for the desktop to be fully loaded ..."
 	until pgrep xfdesktop 1>/dev/null; do {
-		sleep 1
+		sleep 0.2
 	}; done
 }; fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now `xfdesktop` starts in less than a second, resulting in a faster vncserver startup.
Basically I had no intentions of optimizing, it's just I was working on https://github.com/gitpod-io/template-flutter/pull/9 and Xfce was showing an error that `xrdb` command is missing, so I installed `x11-xserver-utils` and apparently Xfce starts faster now.
Also, I learned that a few unnecessary things can be removed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
