### PR TITLE
Add `tmux` and `neovim` chunks and use them in the `full` image

### DIFF
--- a/chunks/tool-neovim/Dockerfile
+++ b/chunks/tool-neovim/Dockerfile
@@ -1,0 +1,11 @@
+ARG base
+FROM ${base}
+
+USER gitpod
+
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_REBUILD=1
+
+RUN curl -o /tmp/nvim.deb -fsSL https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.deb \
+    && sudo apt install /tmp/nvim.deb \
+    && rm -f /tmp/nvim.deb

--- a/chunks/tool-tmux/Dockerfile
+++ b/chunks/tool-tmux/Dockerfile
@@ -1,0 +1,9 @@
+ARG base
+FROM ${base}
+
+USER gitpod
+
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_REBUILD=1
+
+RUN sudo install-packages tmux

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -35,6 +35,7 @@ combiner:
         - tool-brew
         - tool-nginx
         - tool-nix:2.6.0
+        - tool-neovim
     - name: full-vnc
       ref:
       - full

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -36,6 +36,7 @@ combiner:
         - tool-nginx
         - tool-nix:2.6.0
         - tool-neovim
+        - tool-tmux
     - name: full-vnc
       ref:
       - full

--- a/tests/tool-neovim.yaml
+++ b/tests/tool-neovim.yaml
@@ -1,0 +1,6 @@
+- desc: neovim should be installed
+  command: [nvim --version]
+  entrypoint: [bash, -i, -c]
+  assert:
+  - status == 0
+  - stdout.indexOf("NVIM v0.7.0") != -1

--- a/tests/tool-tmux.yaml
+++ b/tests/tool-tmux.yaml
@@ -1,0 +1,6 @@
+- desc: tmux should be installed
+  command: [tmux -V]
+  entrypoint: [bash, -i, -c]
+  assert:
+  - status == 0
+  - stdout.indexOf("tmux") != -1


### PR DESCRIPTION
## Description

Add [neovim](https://neovim.io/) and [tmux](https://github.com/tmux/tmux/wiki) chunks and include them in the `full` workspace image.

We've recently done some great work to make Gitpod easier to use for users with CLI based workflows by making workspaces simpler to access via SSH and supporting `dotfiles` repos to allow customisation of the CLI environment. 
As this is a use-case we want to support, we should also have tools available in the default workspace image that support such a workflow. 

This PR adds `tmux` and `neovim` to the `full` image. `tmux` is the terminal multiplexer, and `neovim` is a modern fork of `vim` with full LSP support that serves as an alternative to full-blown IDEs for users who prefer the CLI.

## Related Issue(s)

## How to test

Dazzle tests added for the two new tools.

## Release Notes

```release-note
Add `tmux` and `neovim` tools to the `full` workspace image
```

## Documentation

None required AFAIK.
