### PR TITLE
Update buildkit to v0.10.2 and do not hide install errors

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.1/buildkit-v0.10.1.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.2/buildkit-v0.10.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.1/buildkit-v0.10.1.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.2/buildkit-v0.10.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,17 +1,17 @@
 FROM gitpod/workspace-full
 
-ENV RETRIGGER=1
+ENV RETRIGGER=2
 
-ENV BUILDKIT_VERSION=0.10.1
+ENV BUILDKIT_VERSION=0.10.2
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 USER root
 
 # Install dazzle, buildkit and pre-commit
-RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr \
-    && curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.11/dazzle_0.1.11_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin \
-    && curl -sSL https://github.com/mvdan/sh/releases/download/v3.4.2/shfmt_v3.4.2_linux_amd64 -o /usr/bin/shfmt \
-    && chmod +x /usr/bin/shfmt \
-    && install-packages shellcheck \
-    && sudo pip3 install pre-commit \
-    && curl -sSL https://github.com/mikefarah/yq/releases/download/v4.22.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr
+RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.11/dazzle_0.1.11_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
+RUN curl -sSL https://github.com/mvdan/sh/releases/download/v3.4.2/shfmt_v3.4.2_linux_amd64 -o /usr/bin/shfmt \
+    && chmod +x /usr/bin/shfmt
+RUN install-packages shellcheck \
+    && pip3 install pre-commit
+RUN curl -sSL https://github.com/mikefarah/yq/releases/download/v4.22.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq


### PR DESCRIPTION
## Description
![Screenshot from 2022-05-03 10-12-11](https://user-images.githubusercontent.com/161571/166469788-79d274af-72b2-4bc9-9f2d-7b3c9baf3400.png)


## Release Notes
```release-note
Update buildkit to v0.10.2 and do not hide install errors
```
