### PR TITLE
Update Ruby to 3.1.2 and 2.7.6

### DIFF
--- a/chunks/lang-ruby/chunk.yaml
+++ b/chunks/lang-ruby/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
   - name: "2.7"
     args:
-      RUBY_VERSION: 2.7.5
+      RUBY_VERSION: 2.7.6
   - name: "3"
     args:
-      RUBY_VERSION: 3.1.0
+      RUBY_VERSION: 3.1.2

--- a/tests/lang-ruby.yaml
+++ b/tests/lang-ruby.yaml
@@ -4,8 +4,8 @@
   assert:
   - status == 0
   - stdout.indexOf("ruby") != -1
-  - stdout.indexOf("2.7.5") != -1 ||
-    stdout.indexOf("3.1.0") != -1
+  - stdout.indexOf("2.7.6") != -1 ||
+    stdout.indexOf("3.1.2") != -1
 - desc: it should have rvm
   command: [rvm --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Update Ruby from 3.1.0 and 2.7.5 to 3.1.2 and 2.7.6.

## Related Issue(s)
- ruby 3.1.x
   - https://www.ruby-lang.org/en/news/2022/02/18/ruby-3-1-1-released/
   - https://www.ruby-lang.org/en/news/2022/04/12/ruby-3-1-2-released/
- ruby 2.7.x
   - https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/

## How to test
Trigger the CI pipeline for this PR.


## Release Notes
```release-note
Bump Ruby to 3.1.2
Bump Ruby to 2.7.6
```

## Documentation
* No