### PR TITLE
Updated go to 1.18.2

### DIFF
--- a/chunks/lang-go/chunk.yaml
+++ b/chunks/lang-go/chunk.yaml
@@ -5,3 +5,6 @@ variants:
   - name: "1.18.1"
     args:
       GO_VERSION: 1.18.1
+  - name: "1.18.2"
+    args:
+      GO_VERSION: 1.18.2

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -26,7 +26,7 @@ combiner:
       chunks:
         - lang-c
         - lang-clojure
-        - lang-go:1.18.1
+        - lang-go:1.18.2
         - lang-java:11
         - lang-node:16
         - lang-python:3.8
@@ -44,7 +44,7 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-go:1.18.1
+        - lang-go:1.18.2
     - name: nix
       ref:
       - base


### PR DESCRIPTION
## Description
Updated go to 1.18.2. The latest stable relase.

## Release Notes
[lang-go] Upgraded to 1.18.2
