### PR TITLE
Install rust completions for gitpod user only

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -54,7 +54,9 @@ USER gitpod
 RUN sudo echo "Running 'sudo' for Gitpod: success" && \
     # create .bashrc.d folder and source it in the bashrc
     mkdir -p /home/gitpod/.bashrc.d && \
-    (echo; echo "for i in \$(ls -A \$HOME/.bashrc.d/); do source \$HOME/.bashrc.d/\$i; done"; echo) >> /home/gitpod/.bashrc
+    (echo; echo "for i in \$(ls -A \$HOME/.bashrc.d/); do source \$HOME/.bashrc.d/\$i; done"; echo) >> /home/gitpod/.bashrc && \
+    # create a completions dir for gitpod user
+    mkdir -p /home/gitpod/.local/share/bash-completion/completions
 
 # configure git-lfs
 RUN sudo git lfs install --system

--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -10,8 +10,8 @@ ENV PATH=$HOME/.cargo/bin:$PATH
 
 RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path --default-toolchain stable \
         -c rls rust-analysis rust-src rustfmt clippy \
-    && rustup completions bash | sudo tee /etc/bash_completion.d/rustup.bash-completion > /dev/null \
-    && rustup completions bash cargo | sudo tee /etc/bash_completion.d/rustup.cargo-bash-completion > /dev/null \
+    && rustup completions bash | tee $HOME/.local/share/bash-completion/completions/rustup > /dev/null \
+    && rustup completions bash cargo | tee $HOME/.local/share/bash-completion/completions/cargo > /dev/null \
     && printf '%s\n'    'export CARGO_HOME=/workspace/.cargo' \
                         'mkdir -m 0755 -p "$CARGO_HOME" 2>/dev/null' \
                         'export PATH=$CARGO_HOME/bin:$PATH' > $HOME/.bashrc.d/80-rust \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Rust is installed using rustup which is supposed to install rust only for current user and not other users including root. See this [comment](https://github.com/gitpod-io/workspace-images/issues/608#issuecomment-1125681443) for more explanation. Adding bash completion for rust is meaningless for other users as they don't have rust installed.

The changes in the base image are required as the official bash-completion readme suggests to use the dir `.local/share/bash-completion/completions/rustup`

Also, `rustup completions bash` suggests [the same](https://rust-lang.github.io/rustup/installation/index.html#enable-tab-completion-for-bash-fish-zsh-or-powershell).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/608

## How to test
<!-- Provide steps to test this PR -->

Fastest way to test this is to create the rust combination and test out the user switch in it. Rust combination because that is the chunk causing the user switch errors.


<summary>
<details>

### Create rust combination
```bash
gitpod /workspace/workspace-images (princerachit/errors-when-switching-608) $ ./build-combo.sh rust
```

### Start the rust container
```bash

gitpod /workspace/workspace-images (princerachit/errors-when-switching-608) $ docker run -it --rm localhost:5000/dazzle:rust
```

### Check autocompletion file exists for gitpod user
```bash

gitpod ~ $ ls ~/.local/share/bash-completion/completions/
cargo  rustup
```
### Check if auto completion works
```bash
gitpod ~ $ cargo 
add                clean              fix                install            new                read-manifest      search             update             workspaces         
b                  clippy             fmt                locate-project     owner              report             set-version        upgrade            ws                 
bench              config             generate-lockfile  login              package            rm                 t                  vendor             yank               
build              d                  git-checkout       logout             pkgid              run                test               verify-project     
c                  doc                help               metadata           publish            rustc              tree               version            
check              fetch              init               miri               r                  rustdoc            uninstall          watch              
gitpod ~ $ rustup 
check           default         dump-testament  help            override        run             show            toolchain       upgrade         --verbose       
completions     doc             -h              install         -q              self            target          uninstall       -v              --version       
component       docs            --help          man             --quiet         set             <+toolchain>    update          -V              which           
```

### Check for user switch errors
```bash

gitpod ~ $ sudo -s
root@fe54a9bde30d:/home/gitpod# exit
exit
gitpod ~ $ sudo su
root@fe54a9bde30d:/home/gitpod# exit
exit
gitpod ~ $ sudo su -
root@fe54a9bde30d:~# exit
logout
gitpod ~ $ sudo -i
root@fe54a9bde30d:~# exit
logout
gitpod ~ $ 
```

</details>

</summary>


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

Added release note as none because this does not really impact users directly, the only thing that will change for the user is that they will not see the error message when switching to a non gitpod user.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
