### PR TITLE
Schedule push of latest images to Dockerhub

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -2,6 +2,8 @@ name: Publish latest images to Docker Hub
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * TUE"
 
 jobs:
   # Sync the 'latest' tag from GAR to Docker Hub


### PR DESCRIPTION
## Description
Push images every Tuesday at 10 am UTC. 

## Related Issue(s)
Fixes #836 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Push latest workspace images to Dockerhub every Tuesday
```