### PR TITLE
Rebuild homebrew layer

### DIFF
--- a/chunks/tool-brew/Dockerfile
+++ b/chunks/tool-brew/Dockerfile
@@ -4,7 +4,7 @@ FROM ${base}
 USER gitpod
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 
 RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/:$PATH


### PR DESCRIPTION
## Description

Rebuild the `brew` layer. 

This looks like it was last done in September 2021 (#502) and some packages are now quite out of date, requiring a lengthy `brew update` operation to make the latest versions available.

## Related Issue(s)
Fixes #

## How to test

## Release Notes
```release-note
Update `brew` layer to get recent versions of all available homebrew packages
```

## Documentation

