### PR TITLE
bump default java from v11 to v17

### DIFF
--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -27,7 +27,7 @@ combiner:
         - lang-c
         - lang-clojure
         - lang-go:1.18.2
-        - lang-java:11
+        - lang-java:17
         - lang-node:16
         - lang-python:3.8
         - lang-ruby:2.7


### PR DESCRIPTION
## Description

bump default java in workspace-full from v11 to v17

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The default JDK is now v17. If you require a different version please use SDKMAN via $ sdk 
```
