### PR TITLE
chore(chunks/tool-nix): Install direnv

### DIFF
--- a/chunks/tool-nix/Dockerfile
+++ b/chunks/tool-nix/Dockerfile
@@ -32,3 +32,8 @@ RUN mkdir -p /home/gitpod/.config/nix && echo $NIX_CONFIG >> /home/gitpod/.confi
 RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
   && nix-env -iA cachix -f https://cachix.org/api/v1/install \
   && cachix use cachix
+
+# Install direnv
+RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
+  && nix-env -i direnv \
+  && direnv hook bash >> /home/gitpod/.bashrc


### PR DESCRIPTION
## Description
This change adds the installation of `direnv`, an important tool when working with Nix. 

## Related Issue(s)
Fixes #847

## How to test
* The command `direnv` will be available in bash
* Any repo configured to use direnv (and uses the default bashrc) will have direnv activated upon opening a terminal session with bash.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Nix image includes direnv
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
