### PR TITLE
Autofix: Keep Java patch versions up-to-date automatically

### DIFF
--- a/.autofix/fixers/update-lang-java.js
+++ b/.autofix/fixers/update-lang-java.js
@@ -1,0 +1,35 @@
+const os = require('os');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+exports.register = async (fixers) => {
+  // TODO: This only lists versions of Java. Maybe we also want to upgrade other SDKMAN tools?
+  //   (E.g. Ant, Gradle, Groovy, Kotlin, Maven, Scala, Spark, Spring Boot, Tomcat, etc.)
+  const { stdout, stderr } = await exec('bash -lc ". $HOME/.sdkman/bin/sdkman-init.sh && yes | sdk update 2>&1" && bash -lc ". $HOME/.sdkman/bin/sdkman-init.sh && sdk list java"');
+  if (stderr) {
+    throw stderr;
+  }
+
+  const patchVersionReplacements = {};
+  for (const line of stdout.split('\n').reverse()) {
+    const cols = line.split('|').map(c => c.trim());
+    if (cols.length !== 6 || cols[5] === 'Identifier' || cols[4] === 'local only') {
+      continue;
+    }
+    const match = cols[5].match(/^(\d+\.\d+\.)(\d+)(.*)$/);
+    if (!match || match.length !== 4) {
+      continue;
+    }
+
+    const pattern = match[1].replace(/\./g, '\\.') + '[0-9][0-9]*' + match[3].replace(/\./g, '\\.');
+    patchVersionReplacements[pattern] = match[0];
+  }
+
+  fixers[0].push({
+    id: 'upgrade-lang-java',
+    cmd: Object.keys(patchVersionReplacements).map(pattern => {
+        return `  sed ${os.type() === 'Darwin' ? '-i "" -E' : '-i -e'} "s/\\(JAVA_VERSION.*\\)${pattern}/\\1${patchVersionReplacements[pattern]}/g" chunks/lang-java/chunk.yaml ;`;
+      }).join('\n'),
+    description: 'update lang-java',
+  });
+};

--- a/chunks/lang-java/Dockerfile
+++ b/chunks/lang-java/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -fsSL "https://get.sdkman.io" | bash \
  && bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
              && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /home/gitpod/.sdkman/etc/config \
              && sed -i 's/sdkman_selfupdate_feature=true/sdkman_selfupdate_feature=false/g' /home/gitpod/.sdkman/etc/config \
-             && sdk install java ${JAVA_VERSION}.fx-zulu \
+             && sdk install java ${JAVA_VERSION} \
              && sdk install gradle \
              && sdk install maven \
              && sdk flush archives \

--- a/chunks/lang-java/chunk.yaml
+++ b/chunks/lang-java/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
   - name: "11"
     args:
-      JAVA_VERSION: 11.0.13
+      JAVA_VERSION: 11.0.13.fx-zulu
   - name: "17"
     args:
-      JAVA_VERSION: 17.0.1
+      JAVA_VERSION: 17.0.1.fx-zulu

--- a/chunks/lang-java/chunk.yaml
+++ b/chunks/lang-java/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
   - name: "11"
     args:
-      JAVA_VERSION: 11.0.13.fx-zulu
+      JAVA_VERSION: 11.0.15.fx-zulu
   - name: "17"
     args:
-      JAVA_VERSION: 17.0.1.fx-zulu
+      JAVA_VERSION: 17.0.3.fx-zulu


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- [x] Refactor Java chunks to use full version strings
- [x] Port [autofix/fixers/upgrade-sdkman-tools.js](https://github.com/autofix-dev/autofix/blob/main/fixers/upgrade-sdkman-tools.js) over as a chunk auto-fixer
- [x] Run `npx autofix` to try it out & upgrade our Java versions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Revert the latest commit (which updates the Java versions)
2. Run `npx autofix`
3. This should create a new local commit which updates the Java chunk versions

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Autofix: Keep Java patch versions up-to-date automatically
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
