### PR TITLE
Update postgresql from 12.10 to 12.11 to address CVE-2022-1552

### DIFF
--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -2,7 +2,7 @@ ARG base
 FROM ${base}
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=2
+ENV TRIGGER_REBUILD=3
 ENV PGWORKSPACE="/workspace/.pgsql"
 ENV PGDATA="$PGWORKSPACE/data"
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

## Description
Updates postgresql from 12.10 (12.10-0ubuntu0.20.04.1) (or 12.9 (12.9-0ubuntu0.20.04.1) in some cases) to 12.11 (12.11-0ubuntu0.20.04.1) to address [CVE-2022-1552](https://www.postgresql.org/support/security/CVE-2022-1552/).

https://packages.ubuntu.com/focal/postgresql-12 and https://packages.ubuntu.com/focal/postgresql-client-12:

```
postgresql-12 (12.11-0ubuntu0.20.04.1) focal-security; urgency=medium

  * New upstream version (LP: #1973627)

    + A dump/restore is not required for those running 12.X.

    + However, if you are upgrading from a version earlier than 12.10,
      see those release notes as well.

    + Confine additional operations within "security restricted operation"
      sandboxes (Sergey Shinderuk, Noah Misch).

      Autovacuum, CLUSTER, CREATE INDEX, REINDEX, REFRESH MATERIALIZED VIEW,
      and pg_amcheck activated the "security restricted operation" protection
      mechanism too late, or even not at all in some code paths. A user having
      permission to create non-temporary objects within a database could
      define an object that would execute arbitrary SQL code with superuser
      permissions the next time that autovacuum processed the object, or that
      some superuser ran one of the affected commands against it.

      The PostgreSQL Project thanks Alexander Lakhin for reporting this
      problem.
      (CVE-2022-1552)

    + Details about these and many further changes can be found at:
      https://www.postgresql.org/docs/12/release-12-11.html

 -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Tue, 17 May 2022 22:10:51 -0400

postgresql-12 (12.10-0ubuntu0.20.04.1) focal; urgency=medium

  * New upstream version (LP: #1961127).

    + A dump/restore is not required for those running 12.X.

    + However, if you have applied REINDEX CONCURRENTLY to a TOAST table's
      index, or observe failures to access TOAST datums, there has been a
      fix for this problem. Any existing corrupted indexes can be repaired
      by reindexing again.

    + Also, if you are upgrading from a version earlier than 12.9, see
      those release notes as well please.

    + Details about these and many further changes can be found at:
      https://www.postgresql.org/docs/12/release-12-10.html

 -- Athos Ribeiro <athos.ribeiro@canonical.com>  Wed, 23 Feb 2022 08:36:18 -0300
```


## Related Issue(s)
Partially address #851

## How to test
Run `psql --version` in a new image built after this PR.

## Release Notes
```release-note
Upgrade postgres from 12.10 to 12.11
```

## Documentation
* No
  * Are you sure? If so, nothing to do here.
