### PR TITLE
Deprecate workspace-python-3.6 image

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -15,7 +15,6 @@
     workspace-node: "20.*"
     workspace-node-lts: "20.*"
     workspace-python: "20.*"
-    workspace-python-3.6: "20.*"
     workspace-python-3.7: "20.*"
     workspace-python-3.8: "20.*"
     workspace-python-3.9: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -12,7 +12,6 @@ sync:
     - node
     - node-lts
     - python
-    - python-3.6
     - python-3.7
     - python-3.8
     - python-3.9

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These images are no longer being published, and not planned for Upgrade:
 
 These images are no longer being published:
 
+1. gitpod/workspace-python-3.6 (please use `gitpod/workspace-python-3.7` instead)
 1. gitpod/workspace-postgresql (please use `gitpod/workspace-postgres` instead)
 
 ## Contributing

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -67,11 +67,6 @@ combiner:
       - base
       chunks:
         - lang-python:3.8
-    - name: python-3.6
-      ref:
-      - base
-      chunks:
-        - lang-python:3.6
     - name: python-3.7
       ref:
       - base


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

## Description
Deprecate [workspace-python-3.6](https://hub.docker.com/r/gitpod/workspace-python-3.6/tags) image as Python 3.6 got EOL in 2021.

## Related Issue(s)
- Fixes #857

## How to test
See if there is no new build for `gitpod/workspace-python-3.6`.

## Release Notes
```release-note
Deprecate gitpod/workspace-python-3.6 image. Use gitpod/workspace-python-3.7 or higher.
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No
