### PR TITLE
Add ruby-3.0 and ruby-3.1 images

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -21,6 +21,8 @@
     workspace-python-3.10: "20.*"
     workspace-ruby-2: "20.*"
     workspace-ruby-3: "20.*"
+    workspace-ruby-3.0: "20.*"
+    workspace-ruby-3.1: "20.*"
     workspace-rust: "20.*"
     workspace-dotnet: "20.*"
     workspace-postgres: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -18,6 +18,8 @@ sync:
     - python-3.10
     - ruby-2
     - ruby-3
+    - ruby-3.0
+    - ruby-3.1
     - rust
     - dotnet
     - postgres

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Each contains a set of chunks: a common base, a language, and includes Docker an
 1. gitpod/workspace-python ✅
 1. gitpod/workspace-ruby-2 ✅
 1. gitpod/workspace-ruby-3 ✅
+1. gitpod/workspace-ruby-3.0 ✅
+1. gitpod/workspace-ruby-3.1 ✅
 1. gitpod/workspace-rust ✅
 1. gitpod/workspace-elixir ✅
 

--- a/chunks/lang-ruby/chunk.yaml
+++ b/chunks/lang-ruby/chunk.yaml
@@ -2,6 +2,9 @@ variants:
   - name: "2.7"
     args:
       RUBY_VERSION: 2.7.6
-  - name: "3"
+  - name: "3.0"
+    args:
+      RUBY_VERSION: 3.0.4
+  - name: "3.1"
     args:
       RUBY_VERSION: 3.1.2

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -92,11 +92,21 @@ combiner:
       - base
       chunks:
         - lang-ruby:2.7
+    - name: ruby-3.0
+      ref:
+      - base
+      chunks:
+        - lang-ruby:3.0
     - name: ruby-3
       ref:
       - base
       chunks:
-        - lang-ruby:3
+        - lang-ruby:3.1
+    - name: ruby-3.1
+      ref:
+      - base
+      chunks:
+        - lang-ruby:3.1
     - name: rust
       ref:
       - base

--- a/tests/lang-ruby.yaml
+++ b/tests/lang-ruby.yaml
@@ -5,6 +5,7 @@
   - status == 0
   - stdout.indexOf("ruby") != -1
   - stdout.indexOf("2.7.6") != -1 ||
+  - stdout.indexOf("3.0.4") != -1 ||
     stdout.indexOf("3.1.2") != -1
 - desc: it should have rvm
   command: [rvm --version]

--- a/tests/lang-ruby.yaml
+++ b/tests/lang-ruby.yaml
@@ -5,7 +5,7 @@
   - status == 0
   - stdout.indexOf("ruby") != -1
   - stdout.indexOf("2.7.6") != -1 ||
-  - stdout.indexOf("3.0.4") != -1 ||
+    stdout.indexOf("3.0.4") != -1 ||
     stdout.indexOf("3.1.2") != -1
 - desc: it should have rvm
   command: [rvm --version]


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

## Description
Add ruby-3.0 and ruby-3.1 images. ruby-3.1 is required as ruby-3 will be upgraded to 3.2 in 6 months.

## Related Issue(s)
Fixes #859

## How to test
See builds.

## Release Notes
```release-note
Add images for Ruby 3.0 and 3.1
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No
