### PR TITLE
chore(chunks/tool-nix): Whitelist /workspace in direnv

### DIFF
--- a/chunks/tool-nix/Dockerfile
+++ b/chunks/tool-nix/Dockerfile
@@ -34,6 +34,9 @@ RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
   && cachix use cachix
 
 # Install direnv
-RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
+RUN mkdir -p /home/gitpod/.config/direnv \
+  && echo '[whitelist]' > .config/direnv/config.toml \
+  && echo 'prefix = [ "/workspace" ]' >> .config/direnv/config.toml \
+  && . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
   && nix-env -i direnv \
   && direnv hook bash >> /home/gitpod/.bashrc


### PR DESCRIPTION
## Description
This whitelists the `/workspace` directory so that users are not required to run `direnv allow` in a new workspace.

## How to test
User will not be prompted to run `direnv allow` in a new workspace where a `.envrc` file is present.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
`direnv allow` is no longer required
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
