### PR TITLE
Extends the access token lifetime

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -71,6 +71,7 @@ jobs:
         uses: google-github-actions/auth@v0.8.0
         with:
           token_format: "access_token"
+          access_token_lifetime: "10800s"
           workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
           service_account: ${{env.IAM_SERVICE_ACCOUNT}}
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -132,18 +132,6 @@ jobs:
         run: |
           sudo skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} ${{ env.DH_IMAGE_REGISTRY }}
 
-      - name: 🔐 Authenticate to Google Cloud again
-        id: "auth_again"
-        uses: google-github-actions/auth@v0.8.0
-        with:
-          token_format: "access_token"
-          workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
-          service_account: ${{env.IAM_SERVICE_ACCOUNT}}
-
-      - name: ✍🏽 Login to GAR using skopeo again
-        run: |
-          sudo skopeo login -u oauth2accesstoken --password=${{ steps.auth_again.outputs.access_token }} ${{env.GAR_IMAGE_REGISTRY}}
-
       - name: 🐳 Sync images with specific tags to Docker Hub
         run: |
             sudo skopeo sync \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Extends the `access_token_lifetime` to 3 hours (10800s) the default value is 1 hour (3600s). 
Reference to
- https://github.com/google-github-actions/auth#generating-oauth-20-access-tokens
- https://cloud.google.com/resource-manager/docs/organization-policy/restricting-service-accounts#extend_oauth_ttl

We added the list constraint `constraints/iam.allowServiceAccountCredentialLifetimeExtension` to the service account `workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com` already.
Reference to https://console.cloud.google.com/iam-admin/orgpolicies/iam-allowServiceAccountCredentialLifetimeExtension?project=gitpod-artifacts&supportedpurview=project

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11067

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A