### PR TITLE
fix(tool-vnc): Fallback to google-chrome from ungoogled_chromium

### DIFF
--- a/chunks/tool-vnc/Dockerfile
+++ b/chunks/tool-vnc/Dockerfile
@@ -6,29 +6,34 @@ ENV TRIGGER_REBUILD=1
 
 USER root
 
-# Install Desktop-ENV, tools and ungoogled_chromium
-RUN curl -sSL https://download.opensuse.org/repositories/home:/ungoogled_chromium/Ubuntu_Focal/Release.key | apt-key add - \
-  && echo 'deb http://download.opensuse.org/repositories/home:/ungoogled_chromium/Ubuntu_Focal/ /' > /etc/apt/sources.list.d/ungoogled_chromium.list \
-  && install-packages xfce4 xfce4-terminal \
-  tigervnc-standalone-server tigervnc-xorg-extension \
-  dbus dbus-x11 gnome-keyring \
-  ungoogled-chromium xdg-utils x11-xserver-utils pip \
-  && ln -srf /usr/bin/chromium /usr/bin/google-chrome
-# To make ungoogled_chromium discoverable by tools like flutter
+# Install Desktop-ENV, tools and google-chrome
+RUN cd /tmp && glink="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+	&& wget -q "$glink" \
+	&& install-packages \
+	tigervnc-standalone-server tigervnc-xorg-extension \
+	dbus dbus-x11 gnome-keyring xfce4 xfce4-terminal \
+	xdg-utils x11-xserver-utils pip ./"${glink##*/}" \
+	&& ln -srf /usr/bin/google-chrome /usr/bin/chromium \
+	# Extra chrome tweaks
+	## Disables welcome screen
+	&& t="$HOME/.config/google-chrome/First Run" && sudo -u gitpod mkdir -p "${t%/*}" && sudo -u gitpod touch "$t" \
+	## Disables default browser prompt
+	&& t="/etc/opt/chrome/policies/managed/managed_policies.json" && mkdir -p "${t%/*}" && printf '{ "%s": %s }\n' DefaultBrowserSettingEnabled false > "$t"
+# OLD: && ln -srf /usr/bin/chromium /usr/bin/google-chrome
+# OLD: To make ungoogled_chromium discoverable by tools like flutter
 
 # Install novnc and numpy module for it
 RUN git clone --depth 1 https://github.com/novnc/noVNC.git /opt/novnc \
-    && git clone --depth 1 https://github.com/novnc/websockify /opt/novnc/utils/websockify \
-    && find /opt/novnc -type d -name '.git' -exec rm -rf '{}' + \
-    && sudo -H pip3 install numpy
+	&& git clone --depth 1 https://github.com/novnc/websockify /opt/novnc/utils/websockify \
+	&& find /opt/novnc -type d -name '.git' -exec rm -rf '{}' + \
+	&& sudo -H pip3 install numpy
 COPY novnc-index.html /opt/novnc/index.html
 
 # Add VNC startup script
 COPY gp-vncsession /usr/bin/
-RUN chmod 0755 $(which gp-vncsession)
-RUN printf '%s\n' 'export DISPLAY=:0' \
-                  'test -v GITPOD_REPO_ROOT && gp-vncsession' >> $HOME/.bashrc
-
+RUN chmod 0755 "$(which gp-vncsession)" \
+	&& printf '%s\n' 'export DISPLAY=:0' \
+	'test -e "$GITPOD_REPO_ROOT" && gp-vncsession' >> "$HOME/.bashrc"
 # Add X11 dotfiles
 COPY --chown=gitpod:gitpod .xinitrc $HOME/
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/workspace-images/issues/872#issuecomment-1179189367

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/872

## How to test
<!-- Provide steps to test this PR -->
I pushed the image to my personal docker account and using here for testing, so you could:
- Create a new workspace from here:
- Run `gp preview $(gp url 6080) --external && chromium --start-fullscreen google.com`
  - It should not display the welcome screen
  - It should not prompt to set itself as the default browser.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix workspace-full-vnc ungoogled_chromium regression
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
