### PR TITLE
feat: enable prebuilds via persisting bazel/blaze cache

### DIFF
--- a/chunks/tool-bazel/Dockerfile
+++ b/chunks/tool-bazel/Dockerfile
@@ -1,0 +1,11 @@
+ARG base
+FROM ${base}
+
+USER gitpod
+
+# Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
+ENV TRIGGER_REBUILD=1
+
+# store the blaze/bazel cache in a place where it will be persisted
+# See also https://docs.bazel.build/versions/main/output_directories.html
+RUN mkdir -p /home/gitpod/.cache/bazel && ln -s /home/gitpod/.cache/bazel /workspace/.bazel

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -32,6 +32,7 @@ combiner:
         - lang-python:3.8
         - lang-ruby:3.1
         - lang-rust
+        - tool-bazel
         - tool-brew
         - tool-nginx
         - tool-nix:2.6.0

--- a/tests/tool-bazel.yaml
+++ b/tests/tool-bazel.yaml
@@ -1,0 +1,5 @@
+- desc: bazel cache should be persisted to /workspaces
+  command: [file, /workspace/.bazel]
+  assert:
+  - status == 0
+  - stdout.indexOf("/workspace/.bazel: symbolic link to /home/gitpod/.cache/bazel") != -1


### PR DESCRIPTION
## Description

Bazel/Blaze by default stores its build cache in a place where Gitpod does not persist thus meaning Blaze/Bazel does not work with prebuilds.

## Related Issue(s)

L10 of https://github.com/carbon-language/carbon-lang/compare/trunk...gitpod-forks:carbon-lang:devenv/gitpod?expand=1#diff-454eff0561fdbb1cdf08bef7a76ddf0f82c65fca08a150c43650f5098ecf7118R10 should not be required.

## How to test

Tests are included but I have not tested running a workspace and am raising pull-request to trigger a CI job.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
feat: enable prebuilds via persisting bazel/blaze cache
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
