### PR TITLE
Update Ruby from 2.7 to 3.1 in gitpod/workspace-full

### DIFF
--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -30,7 +30,7 @@ combiner:
         - lang-java:11
         - lang-node:16
         - lang-python:3.8
-        - lang-ruby:2.7
+        - lang-ruby:3.1
         - lang-rust
         - tool-brew
         - tool-nginx


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Update Ruby from 2.7 to 3.1 in [gitpod/workspace-full](https://hub.docker.com/r/gitpod/workspace-full).

## Related Issue(s)
Fixes #886

## How to test
Check it out: https://github.com/gitpod-io/workspace-images/runs/7464292883?check_suite_focus=true

## Release Notes
```release-note
!Upgrade Ruby from 2.7 to 3.1 in workspace-full image
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No
