### PR TITLE
Update await-port with ports await in gp-cli

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,7 +18,7 @@ tasks:
     openMode: split-right
   - name: dazzle build and test
     command: |
-      gp await-port 5000
+      gp ports await 5000
       REPO=localhost:5000/dazzle
       echo "To build specific chunks and combine them 'time ./build-chunk.sh  -c chunk1 -c chunk2:variant1.2.3 -n combo'"
       echo "To build all the chunks and combinations 'time ./build-all.sh'"


### PR DESCRIPTION
## Description
gp await-port was deprecated in favor of ports await.

## Related Issue(s)
cf. https://github.com/gitpod-io/gitpod/pull/10538

## How to test
Open a Gitpod workspace in review app.

## Release Notes
n/a

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
