### PR TITLE
fix(lang-python): VSCode IntelliSense and DBT extension not working

### DIFF
--- a/chunks/lang-python/Dockerfile
+++ b/chunks/lang-python/Dockerfile
@@ -12,25 +12,27 @@ ENV PIPENV_VENV_IN_PROJECT=true
 ENV PYENV_ROOT="$HOME/.pyenv"
 
 RUN sudo install-packages \
-            # Install python compiling dependencies for pyenv
-            python3-pip make build-essential libssl-dev zlib1g-dev \
-            libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-    # Install PYENV
-    && curl -fsSL https://pyenv.run | bash \
-    && pyenv update \
-    && pyenv install ${PYTHON_VERSION} \
-    && pyenv global ${PYTHON_VERSION} \
-    # Install additional python packages
-    && python3 -m pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --upgrade \
-        setuptools wheel virtualenv pipenv pylint rope flake8 \
-        mypy autopep8 pep8 pylama pydocstyle bandit notebook \
-        twine \
+	# Install python compiling dependencies for pyenv
+	python3-pip make build-essential libssl-dev zlib1g-dev \
+	libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+	libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+	# Install PYENV
+	&& curl -fsSL https://pyenv.run | bash \
+	&& pyenv update \
+	&& pyenv install ${PYTHON_VERSION} \
+	&& pyenv global ${PYTHON_VERSION} \
+	&& for exec in global; do printf '%s\n' 'source "$HOME/.gp_pyenv.d/userbase.bash"' >> "$PYENV_ROOT/libexec/pyenv-$exec"; done \
+	# Install additional python packages
+	&& python3 -m pip install --no-cache-dir --upgrade pip \
+	&& pip install --no-cache-dir --upgrade \
+	setuptools wheel virtualenv pipenv pylint rope flake8 \
+	mypy autopep8 pep8 pylama pydocstyle bandit notebook \
+	twine \
 	# Install poetry
 	&& curl -sSL https://install.python-poetry.org | python \
-    && sudo rm -rf /tmp/*
+	&& sudo rm -rf /tmp/*
 
 COPY --chown=gitpod:gitpod pyenv.d $HOME/.gp_pyenv.d
-COPY --chown=gitpod:gitpod python_bash_hook $HOME/.bashrc.d/60-python
+COPY --chown=gitpod:gitpod userbase.bash $HOME/.gp_pyenv.d
+COPY --chown=gitpod:gitpod python_hook.bash $HOME/.bashrc.d/60-python
 COPY --chown=gitpod:gitpod avoid_userbase_hook.bash $HOME/.pyenv/pyenv.d/exec

--- a/chunks/lang-python/pyenv.d/exec/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/exec/gitpod.bash
@@ -18,13 +18,12 @@ if test "$pyenv_version" != "$mounted_version"; then {
 }; fi
 
 # For pyenv-global multiple-version shims
-if [[ "$PYENV_VERSION" =~ : ]] && [[ "$PYENV_COMMAND_PATH" =~ "$GP_PYENV_MIRROR"/user ]] &&
-	[[ "$(<"$PYENV_COMMAND_PATH")" =~ \#\!"${GP_PYENV_FAKEROOT}"/versions/([0-9]+(\.[0-9]+)*)/bin ]]; then {
-		multi_shim_version="${BASH_REMATCH[1]}"
-		if test "$mounted_version" != "$multi_shim_version"; then {
-			export PYTHONUSERBASE="${PYTHONUSERBASE%/*}/$multi_shim_version"
-		}; fi
-	}; fi 2>/dev/null
+if [[ "$PYENV_VERSION" =~ : ]] && [[ "$PYENV_COMMAND_PATH" =~ "$GP_PYENV_MIRROR"/user ]] && [[ "$(<"$PYENV_COMMAND_PATH")" =~ \#\!("${GP_PYENV_FAKEROOT}"|"$PYENV_ROOT")/versions/([0-9]+(\.[0-9]+)*)/bin ]]; then {
+	multi_shim_version="${BASH_REMATCH[2]}"
+	if test "$mounted_version" != "$multi_shim_version"; then {
+		export PYTHONUSERBASE="${PYTHONUSERBASE%/*}/$multi_shim_version"
+	}; fi
+}; fi 2>/dev/null
 
 # Do not set PIP_USER when `--target` arg is passed to `pip install` to avoid
 ## ERROR: Can not combine '--user' and '--target'.

--- a/chunks/lang-python/pyenv.d/exec/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/exec/gitpod.bash
@@ -8,7 +8,8 @@
 
 # Do not set PIP_USER when `--target` arg is passed to `pip install` to avoid
 ## ERROR: Can not combine '--user' and '--target'.
-export PYTHONUSERBASE="$GP_PYENV_MIRROR/user/$PYENV_VERSION"
+# source "$HOME/.gp_pyenv.d/userbase.bash"
+export PYTHONUSERBASE="$GP_PYENV_MIRROR/user/${PYENV_VERSION%%:*}"
 if [[ "$*" =~ ^pip ]] || [[ "$*" =~ ^python.*-m\ pip ]] && [[ ! "$*" =~ pip.*install.*--target ]]; then {
 	export PIP_USER=true PIP_NO_WARN_SCRIPT_LOCATION=false
 }; fi

--- a/chunks/lang-python/pyenv.d/exec/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/exec/gitpod.bash
@@ -6,10 +6,29 @@
 # 	export PIP_TARGET="$PYTHONPATH" PIP_UPGRADE=true
 # }; fi
 
+# For pyenv-shell mode
+# shellcheck disable=SC2153
+pyenv_version="${PYENV_VERSION%%:*}"
+if test ! -e "$PYTHONUSERBASE_VERSION_FILE"; then {
+	pyenv global 1>/dev/null
+}; fi
+mounted_version="$(<"$PYTHONUSERBASE_VERSION_FILE")"
+if test "$pyenv_version" != "$mounted_version"; then {
+	export PYTHONUSERBASE="${PYTHONUSERBASE%/*}/$pyenv_version"
+}; fi
+
+# For pyenv-global multiple-version shims
+if [[ "$PYENV_VERSION" =~ : ]] && [[ "$PYENV_COMMAND_PATH" =~ "$GP_PYENV_MIRROR"/user ]] &&
+	[[ "$(<"$PYENV_COMMAND_PATH")" =~ \#\!"${GP_PYENV_FAKEROOT}"/versions/([0-9]+(\.[0-9]+)*)/bin ]]; then {
+		multi_shim_version="${BASH_REMATCH[1]}"
+		if test "$mounted_version" != "$multi_shim_version"; then {
+			export PYTHONUSERBASE="${PYTHONUSERBASE%/*}/$multi_shim_version"
+		}; fi
+	}; fi 2>/dev/null
+
 # Do not set PIP_USER when `--target` arg is passed to `pip install` to avoid
 ## ERROR: Can not combine '--user' and '--target'.
 # source "$HOME/.gp_pyenv.d/userbase.bash"
-export PYTHONUSERBASE="$GP_PYENV_MIRROR/user/${PYENV_VERSION%%:*}"
 if [[ "$*" =~ ^pip ]] || [[ "$*" =~ ^python.*-m\ pip ]] && [[ ! "$*" =~ pip.*install.*--target ]]; then {
 	export PIP_USER=true PIP_NO_WARN_SCRIPT_LOCATION=false
 }; fi

--- a/chunks/lang-python/pyenv.d/rehash/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/rehash/gitpod.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+shopt -s nullglob
 gitpod_shims=()
 for file in "$GP_PYENV_MIRROR"/user/*/bin/*; do {
 	gitpod_shims+=("${file##*/}")

--- a/chunks/lang-python/pyenv.d/which/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/which/gitpod.bash
@@ -2,11 +2,14 @@
 # if test ! -x "$PYENV_COMMAND_PATH"; then {\
 ## Give user variant higher priority
 # shellcheck disable=SC2154
-_check_upath="${GP_PYENV_MIRROR}/user/${versions[0]}/bin/$PYENV_COMMAND"
-if test -x "$_check_upath"; then {
-	# shellcheck disable=SC2034
-	PYENV_COMMAND_PATH="$_check_upath"
-}; fi
+for version in "${versions[@]}"; do {
+	_check_upath="${GP_PYENV_MIRROR}/user/${version}/bin/$PYENV_COMMAND"
+	if test -x "$_check_upath"; then {
+		# shellcheck disable=SC2034
+		PYENV_COMMAND_PATH="$_check_upath"
+		break
+	}; fi
+}; done
 
 # Hijack into `pyenv-prefix` to be called from pyenv-whence <arg>
 # This is necessary for pyenv-which to recognize an installed but

--- a/chunks/lang-python/python_bash_hook
+++ b/chunks/lang-python/python_bash_hook
@@ -1,34 +1,52 @@
-if test -e "$GITPOD_REPO_ROOT"; then {
-    export PYENV_HOOK_PATH="$HOME/.gp_pyenv.d"
-    export GP_PYENV_MIRROR="/workspace/.pyenv_mirror"
-    export GP_PYENV_FAKEROOT="$GP_PYENV_MIRROR/fakeroot"
+function pyenv_gitpod_init() {
+	if test -e "$GITPOD_REPO_ROOT"; then {
+		export PYENV_HOOK_PATH="$HOME/.gp_pyenv.d"
+		export GP_PYENV_MIRROR="/workspace/.pyenv_mirror"
+		export GP_PYENV_FAKEROOT="$GP_PYENV_MIRROR/fakeroot"
 
-    if test ! -v GP_PYENV_INIT; then {
-        # Restore installed python versions
-        for version_dir in "$GP_PYENV_FAKEROOT/versions/"*; do {
-            target="$PYENV_ROOT/versions/${version_dir##*/}"
-            mkdir -p "$target"
-            if ! mountpoint -q "$target" && ! sudo mount --bind "$version_dir" "$target" 2>/dev/null; then {
-                rm -rf "$target"
-                ln -s "$version_dir" "$target"
-            } fi
-        } done 2>/dev/null; unset version_dir target
+		if test ! -v GP_PYENV_INIT; then {
+			# Restore installed python versions
+			local target version_dir
+			for version_dir in "$GP_PYENV_FAKEROOT/versions/"*; do {
+				target="$PYENV_ROOT/versions/${version_dir##*/}"
+				mkdir -p "$target"
+				if ! mountpoint -q "$target" && ! sudo mount --bind "$version_dir" "$target" 2>/dev/null; then {
+					rm -rf "$target"
+					ln -s "$version_dir" "$target"
+				} fi
+			} done 2>/dev/null
 
-        # Persistent `pyenv global` version
-        p_version_file="$GP_PYENV_FAKEROOT/version"
-        o_version_file="$PYENV_ROOT/version"
-        if test ! -e "$p_version_file"; then {
-            mkdir -p "${p_version_file%/*}"
-            mv "$o_version_file" "$p_version_file"
-        } fi
-        ln -sf "$p_version_file" "$o_version_file"
-        unset p_version_file o_version_file
-    } fi && export GP_PYENV_INIT=true
+			# Persistent `pyenv global` version
+			local p_version_file="$GP_PYENV_FAKEROOT/version"
+			local o_version_file="$PYENV_ROOT/version"
+			if test ! -e "$p_version_file"; then {
+				mkdir -p "${p_version_file%/*}"
+				mv "$o_version_file" "$p_version_file"
+			} fi
+			ln -sf "$p_version_file" "$o_version_file"
 
-	# Poetry customizations
-	export POETRY_CACHE_DIR="$GP_PYENV_MIRROR/poetry"
+			# Set $HOME/.pyenv/shims/python as the default Interpreter for ms-python.python VSCode extension
+			local settings_name="python.defaultInterpreterPath"
+			local settings_value="$HOME/.pyenv/shims/python"
+			local machine_settings_file="/workspace/.vscode-remote/data/Machine/settings.json"
+			if grep -q "$settings_name" "$machine_settings_file" 2>/dev/null; then {
+				if test ! -e "$machine_settings_file"; then {
+					mkdir -p "${machine_settings_file%/*}"
+					printf '{\n\t"%s": "%s"\n}\n' "$settings_name" "$settings_value" > "$machine_settings_file"
+				} else {
+					sed -i "1s|^{|{ \"$settings_name\": \"$settings_value\"\n|" "$machine_settings_file"
+				} fi
+			} fi
 
-} fi
+		} fi && export GP_PYENV_INIT=true
+
+		# Poetry customizations
+		export POETRY_CACHE_DIR="$GP_PYENV_MIRROR/poetry"
+	} fi
+}
+
+pyenv_gitpod_init
+unset -f pyenv_gitpod_init
 
 # Do not init when sourced internally from `pyenv`
 if test ! -v PYENV_DIR; then {

--- a/chunks/lang-python/python_hook.bash
+++ b/chunks/lang-python/python_hook.bash
@@ -1,20 +1,22 @@
+#!/usr/bin/env bash
 function pyenv_gitpod_init() {
 	if test -e "$GITPOD_REPO_ROOT"; then {
 		export PYENV_HOOK_PATH="$HOME/.gp_pyenv.d"
 		export GP_PYENV_MIRROR="/workspace/.pyenv_mirror"
 		export GP_PYENV_FAKEROOT="$GP_PYENV_MIRROR/fakeroot"
+		export PYTHONUSERBASE="$GP_PYENV_MIRROR/user/current"
 
 		if test ! -v GP_PYENV_INIT; then {
 			# Restore installed python versions
 			local target version_dir
 			for version_dir in "$GP_PYENV_FAKEROOT/versions/"*; do {
 				target="$PYENV_ROOT/versions/${version_dir##*/}"
-				mkdir -p "$target"
+				mkdir -p "$target" 2>/dev/null
 				if ! mountpoint -q "$target" && ! sudo mount --bind "$version_dir" "$target" 2>/dev/null; then {
 					rm -rf "$target"
 					ln -s "$version_dir" "$target"
-				} fi
-			} done 2>/dev/null
+				}; fi
+			}; done 2>/dev/null
 
 			# Persistent `pyenv global` version
 			local p_version_file="$GP_PYENV_FAKEROOT/version"
@@ -22,27 +24,30 @@ function pyenv_gitpod_init() {
 			if test ! -e "$p_version_file"; then {
 				mkdir -p "${p_version_file%/*}"
 				mv "$o_version_file" "$p_version_file"
-			} fi
+			}; fi
 			ln -sf "$p_version_file" "$o_version_file"
 
-			# Set $HOME/.pyenv/shims/python as the default Interpreter for ms-python.python VSCode extension
-			local settings_name="python.defaultInterpreterPath"
-			local settings_value="$HOME/.pyenv/shims/python"
-			local machine_settings_file="/workspace/.vscode-remote/data/Machine/settings.json"
-			if grep -q "$settings_name" "$machine_settings_file" 2>/dev/null; then {
-				if test ! -e "$machine_settings_file"; then {
-					mkdir -p "${machine_settings_file%/*}"
-					printf '{\n\t"%s": "%s"\n}\n' "$settings_name" "$settings_value" > "$machine_settings_file"
-				} else {
-					sed -i "1s|^{|{ \"$settings_name\": \"$settings_value\"\n|" "$machine_settings_file"
-				} fi
-			} fi
+			# Init userbase hook
+			# shellcheck source=/dev/null
+			(PYENV_VERSION="$(pyenv version-name)" && export PYENV_VERSION && source "$HOME/.gp_pyenv.d/userbase.bash")
+		}; fi && export GP_PYENV_INIT=true
 
-		} fi && export GP_PYENV_INIT=true
+		# Set $HOME/.pyenv/shims/python as the default Interpreter for ms-python.python VSCode extension
+		local settings_name="python.defaultInterpreterPath"
+		local settings_value="$HOME/.pyenv/shims/python"
+		local machine_settings_file="/workspace/.vscode-remote/data/Machine/settings.json"
+		if ! grep -q "$settings_name" "$machine_settings_file" 2>/dev/null; then {
+			if test ! -e "$machine_settings_file"; then {
+				mkdir -p "${machine_settings_file%/*}"
+				printf '{\n\t"%s": "%s"\n}\n' "$settings_name" "$settings_value" >"$machine_settings_file"
+			}; else {
+				sed -i "1s|^{|{ \"$settings_name\": \"$settings_value\"\n|" "$machine_settings_file"
+			}; fi
+		}; fi
 
 		# Poetry customizations
 		export POETRY_CACHE_DIR="$GP_PYENV_MIRROR/poetry"
-	} fi
+	}; fi
 }
 
 pyenv_gitpod_init
@@ -50,6 +55,6 @@ unset -f pyenv_gitpod_init
 
 # Do not init when sourced internally from `pyenv`
 if test ! -v PYENV_DIR; then {
-    eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -)"
-} fi
+	eval "$(pyenv init -)"
+	eval "$(pyenv virtualenv-init -)"
+}; fi

--- a/chunks/lang-python/python_hook.bash
+++ b/chunks/lang-python/python_hook.bash
@@ -28,7 +28,7 @@ function pyenv_gitpod_init() {
 			ln -sf "$p_version_file" "$o_version_file"
 
 			# Init userbase hook
-			# shellcheck source=/dev/null
+			# shellcheck source=$HOME
 			(PYENV_VERSION="$(pyenv version-name)" && export PYENV_VERSION && source "$HOME/.gp_pyenv.d/userbase.bash")
 		}; fi && export GP_PYENV_INIT=true
 

--- a/chunks/lang-python/userbase.bash
+++ b/chunks/lang-python/userbase.bash
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 if test -e "$GITPOD_REPO_ROOT"; then {
 
-	# For pyenv-global and pyenv-sh-shell hook
-	if test ! -v PYENV_VERSION; then {
+	# For pyenv-global hook
+	if test ! -v PYENV_VERSION && test "${BASH_SOURCE[1]}" == "$PYENV_ROOT/libexec/pyenv-global"; then {
 		# shellcheck disable=SC2154
 		PYENV_VERSION="${versions[0]}"
 		if [[ ! "$PYENV_VERSION" =~ \. ]]; then {
@@ -24,12 +24,14 @@ if test -e "$GITPOD_REPO_ROOT"; then {
 	mounted_version="$(<"$mounted_version_file")"
 
 	# shellcheck disable=SC2034
-	if ! mountpoint -q "$system_python_userbase" && not_mounted=true || test "$mounted_version" -ne "$pyenv_version"; then {
-		mkdir -p "$system_python_userbase" 2>/dev/null || :
+	if ! mountpoint -q "$system_python_userbase" && not_mounted=true || test "$mounted_version" != "$pyenv_version"; then {
+		mkdir -p "$system_python_userbase" "$versioned_python_userbase_dir" 2>/dev/null
 		if test ! -v not_mounted; then {
-			sudo umount -lf "$system_python_userbase" 2>/dev/null || :
+			while mountpoint -q "$system_python_userbase"; do {
+				sudo umount "$system_python_userbase" || sudo umount -l "$system_python_userbase"
+			}; done
 		}; fi
-		if ! sudo mount --bind "$versioned_python_userbase_dir" "$system_python_userbase" 2>/dev/null; then {
+		if ! sudo mount --bind "$versioned_python_userbase_dir" "$system_python_userbase"; then {
 			rm -rf "$system_python_userbase"
 			ln -s "$versioned_python_userbase_dir" "$system_python_userbase"
 		}; fi

--- a/chunks/lang-python/userbase.bash
+++ b/chunks/lang-python/userbase.bash
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-if test -e "$GITPOD_REPO_ROOT"; then {
-
-	# For pyenv-global hook
-	if test ! -v PYENV_VERSION && test "${BASH_SOURCE[1]}" == "$PYENV_ROOT/libexec/pyenv-global"; then {
-		# shellcheck disable=SC2154
-		PYENV_VERSION="${versions[0]}"
-		if [[ ! "$PYENV_VERSION" =~ \. ]]; then {
-			exit
-		}; fi
-
+set -eu
+if test -e "${GITPOD_REPO_ROOT:-}" && test "${BASH_SOURCE[1]}" == "$PYENV_ROOT/libexec/pyenv-global"; then {
+	# # For pyenv-global hook
+	# if test ! -v PYENV_VERSION && ; then {
+	# shellcheck disable=SC2154
+	PYENV_VERSION="${versions[0]}"
+	if [[ ! "$PYENV_VERSION" =~ \.|system ]]; then {
+		exit
 	}; fi
+
+	# }; fi
 	pyenv_version="${PYENV_VERSION%%:*}"
 	system_python_userbase="$PYTHONUSERBASE"
 	userbase_dir="$GP_PYENV_MIRROR/user"
 	versioned_python_userbase_dir="$userbase_dir/$pyenv_version"
-	mounted_version_file="$userbase_dir/.mounted_version"
+	mounted_version_file="$PYTHONUSERBASE_VERSION_FILE"
 
 	if test ! -s "$mounted_version_file"; then {
 		mkdir -p "${mounted_version_file%/*}"
@@ -31,7 +31,7 @@ if test -e "$GITPOD_REPO_ROOT"; then {
 				sudo umount "$system_python_userbase" || sudo umount -l "$system_python_userbase"
 			}; done
 		}; fi
-		if ! sudo mount --bind "$versioned_python_userbase_dir" "$system_python_userbase"; then {
+		if ! sudo mount --bind "$versioned_python_userbase_dir" "$system_python_userbase" 2>/dev/null; then {
 			rm -rf "$system_python_userbase"
 			ln -s "$versioned_python_userbase_dir" "$system_python_userbase"
 		}; fi

--- a/chunks/lang-python/userbase.bash
+++ b/chunks/lang-python/userbase.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+if test -e "$GITPOD_REPO_ROOT"; then {
+
+	# For pyenv-global and pyenv-sh-shell hook
+	if test ! -v PYENV_VERSION; then {
+		# shellcheck disable=SC2154
+		PYENV_VERSION="${versions[0]}"
+		if [[ ! "$PYENV_VERSION" =~ \. ]]; then {
+			exit
+		}; fi
+
+	}; fi
+	pyenv_version="${PYENV_VERSION%%:*}"
+	system_python_userbase="$PYTHONUSERBASE"
+	userbase_dir="$GP_PYENV_MIRROR/user"
+	versioned_python_userbase_dir="$userbase_dir/$pyenv_version"
+	mounted_version_file="$userbase_dir/.mounted_version"
+
+	if test ! -s "$mounted_version_file"; then {
+		mkdir -p "${mounted_version_file%/*}"
+		printf '%s\n' "$pyenv_version" >"$mounted_version_file"
+	}; fi
+
+	mounted_version="$(<"$mounted_version_file")"
+
+	# shellcheck disable=SC2034
+	if ! mountpoint -q "$system_python_userbase" && not_mounted=true || test "$mounted_version" -ne "$pyenv_version"; then {
+		mkdir -p "$system_python_userbase" 2>/dev/null || :
+		if test ! -v not_mounted; then {
+			sudo umount -lf "$system_python_userbase" 2>/dev/null || :
+		}; fi
+		if ! sudo mount --bind "$versioned_python_userbase_dir" "$system_python_userbase" 2>/dev/null; then {
+			rm -rf "$system_python_userbase"
+			ln -s "$versioned_python_userbase_dir" "$system_python_userbase"
+		}; fi
+		printf '%s\n' "$pyenv_version" >"$mounted_version_file"
+	}; fi
+}; fi

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -50,11 +50,11 @@
   assert:
     - status == 0
 
-- desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env"
+- desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
   entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
   command:
     [
-      ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver,
+      ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod,
     ]
   assert:
     - status == 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
```
fix: ms-python.python using system python as interpreter by default instead of pyenv and static PYTHONUSERBASE
```

`ms-python.python` defaults to the system(`/usr/bin/python*`) instead of our customized `pyenv` setup under `$HOME/.pyenv`, which causes issues as from the terminal `pyenv` python interpreters are used but not `/usr/bin/python*`. So `ms-python.python` is then not aware of pyenv, causing issues such as:

1. User is confused why their `import` isn't working on VSCode editor
2. User is confused why auto complete/IntelliSense isn't working for python
3. Extensions that depend on [`ms-python.python` API](https://github.com/microsoft/vscode-python/wiki/Proposed-Environment-APIs#environment-apis) fails to locate their python dependencies, for example [vscode-dbt-power-user](https://github.com/innoverio/vscode-dbt-power-user)
4. Now someone will not need to use `sudo pip install` to workaround anymore as it was done [here](https://github.com/dtger/dbt-gitpod-example/blob/55de5e022657ab9e842d000c937c628dea30a070/.gitpod.dbt.dockerfile#L10) for this [Blog post](https://gitpod.slack.com/archives/C01KGM9AGBG/p1656580114008159)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes:
- [This issue discussed on Slack](https://gitpod.slack.com/archives/C020VCB0U5A/p1656576871988859) (relates with point `3.` above in #Description)
- https://app.frontapp.com/open/cnv_jndu8ui
- https://app.frontapp.com/open/cnv_jeobo5m
- https://discord.com/channels/816244985187008514/1000294219413467137
- https://gitpod.slack.com/archives/C01LDA27WJC/p1659066982709069
- https://github.com/gitpod-io/gitpod/issues/11482

## How to test
<!-- Provide steps to test this PR -->
I built the `python` combo and pushed to my dockerhub.
- Create a workspace from this branch: https://github.com/gitpod-io/dbt-main/tree/dbt_in_gitpod

### 1. Testing the usability of VSCode extensions that depend on [ms-python.python API](https://github.com/microsoft/vscode-python/wiki/Proposed-Environment-APIs#environment-apis)
----
- Check if `dbt` extension is able to locate it's local `python` dependencies.
<img width="698" alt="Screenshot 2022-08-03 at 5 13 38 PM" src="https://user-images.githubusercontent.com/39482679/182595078-670b408f-f641-43ec-9d3e-e215263311ea.png">

### 2. Testing VSCode IntelliSense for python
----
- Run `pip install aiohttp && code test.py` and copy paste code from [here](https://docs.aiohttp.org/en/stable/#client-example)
  - hover on methods, make edits and check suggestion trigger for methods/functions
 
|IntelliSense|Doc tooltip|
|----|----|
|<img width="831" alt="Screenshot 2022-08-03 at 5 21 31 PM" src="https://user-images.githubusercontent.com/39482679/182596040-a38432be-3cdf-4f51-a529-477524de7659.png">|<img width="797" alt="Screenshot 2022-08-03 at 5 22 42 PM" src="https://user-images.githubusercontent.com/39482679/182596168-95937779-077f-4a1c-ab2f-0c4f2ab5a625.png">|

  - Lastly run the script to see if things are working alright: `python test.py`

### 3. Testing pyenv PYTHONUSERBASE multi-version shim support
----
- At first install a separate python version: `pyenv install 3.6.0` (for example)
- Default it for the shell session: `pyenv shell 3.6.0`
- Install some tool/CLI: `pip install cowsay` (for example)
- Now `cowsay` would be installed for python `3.6.0`, let's switch back to the default version: `pyenv shell --unset`
- Try running the following command: `cowsay Hello`, it should throw an error.
- Now set multiple version for the global/shell environment: `pyenv shell 3.8.13 3.6.0` or `pyenv global 3.8.13 3.6.0`
- Finally run it again: `cowsay Hello`, it should work even from within the `$PYTHONUSERBASE`(you can check `cowsay`'s location by `pyenv which cowsay`)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix(lang-python): VSCode IntelliSense and DBT extension not working
fea(lang-python): pyenv multi-version shim support for PYTHONUSERBASE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
