### PR TITLE
Update clang to v15

### DIFF
--- a/chunks/lang-c/Dockerfile
+++ b/chunks/lang-c/Dockerfile
@@ -8,7 +8,7 @@ ENV TRIGGER_REBUILD=1
 
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ \
-    llvm-toolchain-focal main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
+    llvm-toolchain-focal-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
     && apt update \
     && install-packages \
         clang \


### PR DESCRIPTION
## Description

Fix clang issues

## Related Issue(s)

```
cannot test chunk lang-c: failed to solve: process "/bin/sh -c curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg     && echo \"deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/     llvm-toolchain-focal main\" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null     && apt update     && install-packages         clang         clangd         clang-format         clang-tidy         gdb         lld" did not complete successfully: exit code: 100
#6 7.805 The following packages have unmet dependencies:
#6 7.889  clang : Depends: clang-15 (>= 15~) but it is not installable
#6 7.889  clang-format : Depends: clang-format-15 (>= 15~) but it is not installable
#6 7.889  clang-tidy : Depends: clang-tidy-15 (>= 15~) but it is not installable
#6 7.889  clangd : Depends: clangd-15 (>= 15~) but it is not installable
#6 7.891  lld : Depends: lld-15 (>= 15~) but it is not installable
#6 7.906 E: Unable to correct problems, you have held broken packages.
``` 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Updtae clang to v15
```
