### PR TITLE
Refactor installation of Chrome on the VNC image

### DIFF
--- a/chunks/tool-chrome/Dockerfile
+++ b/chunks/tool-chrome/Dockerfile
@@ -7,18 +7,24 @@ USER root
 ENV TRIGGER_REBUILD=1
 
 # chrome and basic render font
-RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/chrome-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/chrome-archive-keyring.gpg] https://dl.google.com/linux/chrome/deb/ \
-    stable main" | tee /etc/apt/sources.list.d/google-chrome.list > /dev/null \
-    && apt update \
-    && install-packages google-chrome-stable
-
-USER gitpod
-
+# google-chrome
 # misc deps for electron and puppeteer to run
-RUN sudo install-packages \
-    libasound2-dev libgtk-3-dev libnss3-dev \
-    fonts-noto fonts-noto-cjk
+RUN cd /tmp && glink="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+	&& wget -q "$glink" \
+	&& install-packages libasound2-dev libgtk-3-dev libnss3-dev \
+	fonts-noto fonts-noto-cjk ./"${glink##*/}" \
+	\
+	# OLD: && ln -srf /usr/bin/chromium /usr/bin/google-chrome
+	# OLD: To make ungoogled_chromium discoverable by tools like flutter
+	&& ln -srf /usr/bin/google-chrome /usr/bin/chromium \
+	\
+	# Extra chrome tweaks
+	## Disables welcome screen
+	&& t="$HOME/.config/google-chrome/First Run" && sudo -u gitpod mkdir -p "${t%/*}" && sudo -u gitpod touch "$t" \
+	## Disables default browser prompt
+	&& t="/etc/opt/chrome/policies/managed/managed_policies.json" && mkdir -p "${t%/*}" && printf '{ "%s": %s }\n' DefaultBrowserSettingEnabled false > "$t"
 
 # For Qt WebEngine on docker
 ENV QTWEBENGINE_DISABLE_SANDBOX 1
+
+USER gitpod

--- a/chunks/tool-vnc/Dockerfile
+++ b/chunks/tool-vnc/Dockerfile
@@ -6,21 +6,11 @@ ENV TRIGGER_REBUILD=1
 
 USER root
 
-# Install Desktop-ENV, tools and google-chrome
-RUN cd /tmp && glink="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-	&& wget -q "$glink" \
-	&& install-packages \
+# Install Desktop-ENV, tools
+RUN install-packages \
 	tigervnc-standalone-server tigervnc-xorg-extension \
 	dbus dbus-x11 gnome-keyring xfce4 xfce4-terminal \
-	xdg-utils x11-xserver-utils pip ./"${glink##*/}" \
-	&& ln -srf /usr/bin/google-chrome /usr/bin/chromium \
-	# Extra chrome tweaks
-	## Disables welcome screen
-	&& t="$HOME/.config/google-chrome/First Run" && sudo -u gitpod mkdir -p "${t%/*}" && sudo -u gitpod touch "$t" \
-	## Disables default browser prompt
-	&& t="/etc/opt/chrome/policies/managed/managed_policies.json" && mkdir -p "${t%/*}" && printf '{ "%s": %s }\n' DefaultBrowserSettingEnabled false > "$t"
-# OLD: && ln -srf /usr/bin/chromium /usr/bin/google-chrome
-# OLD: To make ungoogled_chromium discoverable by tools like flutter
+	xdg-utils x11-xserver-utils pip
 
 # Install novnc and numpy module for it
 RUN git clone --depth 1 https://github.com/novnc/noVNC.git /opt/novnc \

--- a/chunks/tool-vnc/Dockerfile
+++ b/chunks/tool-vnc/Dockerfile
@@ -7,12 +7,10 @@ ENV TRIGGER_REBUILD=1
 USER root
 
 # Install Desktop-ENV, tools and google-chrome
-RUN cd /tmp && glink="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-	&& wget -q "$glink" \
-	&& install-packages \
+RUN install-packages \
 	tigervnc-standalone-server tigervnc-xorg-extension \
 	dbus dbus-x11 gnome-keyring xfce4 xfce4-terminal \
-	xdg-utils x11-xserver-utils pip ./"${glink##*/}" \
+	xdg-utils x11-xserver-utils pip \
 	&& ln -srf /usr/bin/google-chrome /usr/bin/chromium \
 	# Extra chrome tweaks
 	## Disables welcome screen

--- a/chunks/tool-vnc/Dockerfile
+++ b/chunks/tool-vnc/Dockerfile
@@ -7,10 +7,12 @@ ENV TRIGGER_REBUILD=1
 USER root
 
 # Install Desktop-ENV, tools and google-chrome
-RUN install-packages \
+RUN cd /tmp && glink="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+	&& wget -q "$glink" \
+	&& install-packages \
 	tigervnc-standalone-server tigervnc-xorg-extension \
 	dbus dbus-x11 gnome-keyring xfce4 xfce4-terminal \
-	xdg-utils x11-xserver-utils pip \
+	xdg-utils x11-xserver-utils pip ./"${glink##*/}" \
 	&& ln -srf /usr/bin/google-chrome /usr/bin/chromium \
 	# Extra chrome tweaks
 	## Disables welcome screen

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -34,7 +34,6 @@ combiner:
         - lang-rust
         - tool-brew
         - tool-nginx
-        - tool-chrome
         - tool-nix:2.6.0
     - name: full-vnc
       ref:

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -34,6 +34,7 @@ combiner:
         - lang-rust
         - tool-brew
         - tool-nginx
+        - tool-chrome
         - tool-nix:2.6.0
     - name: full-vnc
       ref:

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -40,6 +40,7 @@ combiner:
       ref:
       - full
       chunks:
+        - tool-chrome
         - tool-vnc
     - name: go
       ref:


### PR DESCRIPTION
## Description

I feel really unconveninent without it in full image. I checked the size, it's only around 130m increase.
It should be in full in the long run.
This will make frontend e2e testing like cypress and Puppeteer more out of the box.
Also benefit for development like qt, jetbrains plugin development, gitbook generating.


context: https://github.com/gitpod-io/workspace-images/pull/471/

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
