### PR TITLE
docs: add architecture info & dockerhub url

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,8 +3,6 @@ MD003:
   style: atx
 MD007:
   indent: 4
-MD013:
-  line_length: 200
 MD033: false
 no-inline-html:
   allowed_elements:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Workspaces started based on this default image come pre-installed with Docker, N
 
 If this image does not include the tools you need for your repository, we recommend you start with [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3) and customize it according to your needs. You can refer to this [document to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
 
-OR, [Bring your Dockerfile](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-public-docker-image).
-
-
 ### 📷 Images we'll maintain
 
 - [`gitpod/workspace-full`](https://hub.docker.com/r/gitpod/workspace-full) ✅

--- a/README.md
+++ b/README.md
@@ -3,70 +3,83 @@
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/gitpod-io/workspace-images)
 [![Build from Main](https://github.com/gitpod-io/workspace-images/actions/workflows/push-main.yml/badge.svg)](https://github.com/gitpod-io/workspace-images/actions/workflows/push-main.yml)
 
-Ready-to-use Docker images for [gitpod.io](https://www.gitpod.io) workspaces. All images are available on Docker Hub under [gitpod/*](https://hub.docker.com/u/gitpod).
-For examples on how to use these images please take a look at the [documentation](https://www.gitpod.io/docs/config-docker#configure-a-public-docker-image).
+Ready-to-use Docker images for [gitpod.io](https://www.gitpod.io) workspaces. All images are available on [Gitpod's Dockerhub page](https://hub.docker.com/u/gitpod).
+
+For an example of how to use these images, please take a look at the [documentation](https://www.gitpod.io/docs/config-docker#configure-a-public-docker-image).
 
 ## 📢 Announcements
 
 We upgraded to support [dazzle v2](https://github.com/gitpod-io/dazzle) and build with GitHub Actions.
 
-### 📷 Images we'll upgrade
+## Summary
 
-1. gitpod/workspace-full ✅
-1. gitpod/workspace-base ✅
-1. gitpod/workspace-dotnet ✅
-1. gitpod/workspace-full-vnc ✅
-1. gitpod/workspace-mongodb ✅
-1. gitpod/workspace-mysql ✅
-1. gitpod/workspace-postgres ✅
+- **Operating System**: Ubuntu 20.04.4 LTS
+- **OS Type**: linux
+- **Architecture**: x86_64
 
-### 🆕 Images
+## Images
+
+By default, Gitpod uses a standard Docker Image called [`workspace-full`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L23) as the foundation for workspaces. Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as tools such as Homebrew, Tailscale, Nginx and several more.
+
+If this image does not include the tools you need for your repository, we recommend you to use [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L3) & [Bring your Dockerfile](https://www.gitpod.io/blog/docker-in-gitpod), according to your repository. You can refer this [documentation to setup a custom docker image](https://www.gitpod.io/docs/config-docker).
+
+### 📷 Images we'll maintain
+
+- [`gitpod/workspace-full`](https://hub.docker.com/r/gitpod/workspace-full) ✅
+- [`gitpod/workspace-base`](https://hub.docker.com/r/gitpod/workspace-base) ✅
+- [`gitpod/workspace-dotnet`](https://hub.docker.com/r/gitpod/workspace-dotnet) ✅
+- [`gitpod/workspace-full-vnc`](https://hub.docker.com/r/gitpod/workspace-full-vnc) ✅
+- [`gitpod/workspace-mongodb`](https://hub.docker.com/r/gitpod/workspace-mongodb) ✅
+- [`gitpod/workspace-mysql`](https://hub.docker.com/r/gitpod/workspace-mysql) ✅
+- [`gitpod/workspace-postgres`](https://hub.docker.com/r/gitpod/workspace-postgres) ✅
+
+### 🆕 Specific Images
 
 These are lightweight compared to `gitpod/workspace-full`.
 
-Each contains a set of chunks: a common base, a language, and includes Docker and Tailscale.
+Each contains a set of chunks: a common base, and a language, and includes Docker and Tailscale.
 
-1. gitpod/workspace-c ✅
-1. gitpod/workspace-clojure ✅
-1. gitpod/workspace-go ✅
-1. gitpod/workspace-java-11 ✅
-1. gitpod/workspace-java-17 ✅
-1. gitpod/workspace-node ✅
-1. gitpod/workspace-node-lts ✅
-1. gitpod/workspace-python ✅
-1. gitpod/workspace-ruby-2 ✅
-1. gitpod/workspace-ruby-3 ✅
-1. gitpod/workspace-ruby-3.0 ✅
-1. gitpod/workspace-ruby-3.1 ✅
-1. gitpod/workspace-rust ✅
-1. gitpod/workspace-elixir ✅
+- [`gitpod/workspace-c`](https://hub.docker.com/r/gitpod/workspace-c) ✅
+- [`gitpod/workspace-clojure`](https://hub.docker.com/r/gitpod/workspace-clojure) ✅
+- [`gitpod/workspace-go`](https://hub.docker.com/r/gitpod/workspace-go) ✅
+- [`gitpod/workspace-java-11`](https://hub.docker.com/r/gitpod/workspace-java-11) ✅
+- [`gitpod/workspace-java-17`](https://hub.docker.com/r/gitpod/workspace-java-17) ✅
+- [`gitpod/workspace-node`](https://hub.docker.com/r/gitpod/workspace-node) ✅
+- [`gitpod/workspace-node-lts`](https://hub.docker.com/r/gitpod/workspace-node-lts) ✅
+- [`gitpod/workspace-python`](https://hub.docker.com/r/gitpod/workspace-python) ✅
+- [`gitpod/workspace-ruby-2`](https://hub.docker.com/r/gitpod/workspace-ruby-2) ✅
+- [`gitpod/workspace-ruby-3`](https://hub.docker.com/r/gitpod/workspace-ruby-3) ✅
+- [`gitpod/workspace-ruby-3.0`](https://hub.docker.com/r/gitpod/workspace-ruby-3.0) ✅
+- [`gitpod/workspace-ruby-3.1`](https://hub.docker.com/r/gitpod/workspace-ruby-3.1) ✅
+- [`gitpod/workspace-rust`](https://hub.docker.com/r/gitpod/workspace-rust) ✅
+- [`gitpod/workspace-elixir`](https://hub.docker.com/r/gitpod/workspace-elixir) ✅
 
 ### 🎬 No upgrade planned
 
-These images are no longer being published, and not planned for Upgrade:
+⚠️ These images are no longer being published, and are not planned for Upgrade:
 
-1. gitpod/workspace-images-dazzle
-1. gitpod/workspace-dotnet-vnc
-1. gitpod/workspace-dotnet-lts
-1. gitpod/workspace-dotnet-lts-vnc
-1. gitpod/workspace-flutter
-1. gitpod/workspace-gecko
-1. gitpod/workspace-wasm
-1. gitpod/workspace-firefox
-1. gitpod/workspace-full-dazzle
-1. gitpod/workspace-mysql-8
-1. gitpod/workspace-python-tk-vnc
-1. gitpod/workspace-python-tk
-1. gitpod/workspace-rethinkdb
-1. gitpod/workspace-thin
-1. gitpod/workspace-webassembly
+- gitpod/workspace-images-dazzle
+- gitpod/workspace-dotnet-vnc
+- gitpod/workspace-dotnet-lts
+- gitpod/workspace-dotnet-lts-vnc
+- gitpod/workspace-flutter
+- gitpod/workspace-gecko
+- gitpod/workspace-wasm
+- gitpod/workspace-firefox
+- gitpod/workspace-full-dazzle
+- gitpod/workspace-mysql-8
+- gitpod/workspace-python-tk-vnc
+- gitpod/workspace-python-tk
+- gitpod/workspace-rethinkdb
+- gitpod/workspace-thin
+- gitpod/workspace-webassembly
 
 ### 📢 Deprecated images
 
 These images are no longer being published:
 
-1. gitpod/workspace-python-3.6 (please use `gitpod/workspace-python-3.7` instead)
-1. gitpod/workspace-postgresql (please use `gitpod/workspace-postgres` instead)
+- gitpod/workspace-python-3.6 (please use [`gitpod/workspace-python-3.7`](https://hub.docker.com/r/gitpod/workspace-python-3.7) instead)
+- gitpod/workspace-postgresql (please use [`gitpod/workspace-postgres`](https://hub.docker.com/r/gitpod/workspace-postgres) instead)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Ready-to-use Docker images for [gitpod.io](https://www.gitpod.io) workspaces. All images are available on [Gitpod's Dockerhub page](https://hub.docker.com/u/gitpod).
 
-For an example of how to use these images, please take a look at the [documentation](https://www.gitpod.io/docs/config-docker#configure-a-public-docker-image).
+For an example of how to use these images, please take a look at the [documentation](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-public-docker-image).
 
 ## 📢 Announcements
 
@@ -21,7 +21,7 @@ We upgraded to support [dazzle v2](https://github.com/gitpod-io/dazzle) and buil
 
 By default, Gitpod uses a standard Docker Image called [`workspace-full`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L23) as the foundation for workspaces. Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as tools such as Homebrew, Tailscale, Nginx and several more.
 
-If this image does not include the tools you need for your repository, we recommend you to use [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L3) & [Bring your Dockerfile](https://www.gitpod.io/blog/docker-in-gitpod), according to your repository. You can refer this [documentation to setup a custom docker image](https://www.gitpod.io/docs/config-docker).
+If this image does not include the tools you need for your repository, we recommend you to use [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L3) & [Bring your Dockerfile](https://www.gitpod.io/blog/docker-in-gitpod), according to your repository. You can refer this [documentation to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
 
 ### 📷 Images we'll maintain
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ By default, Gitpod uses a standard Docker Image called [`workspace-full`](https:
 
 Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust & PHP as well as tools such as Homebrew, Tailscale, Nginx & several more.
 
-If this image does not include the tools you need for your repository, we recommend you start with [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3) and,
-
-customize it according to your needs. You can refer to this [document to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
+If this image does not include the tools you need for your repository, we recommend you start with [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3) and customize it according to your needs. You can refer to this [document to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
 
 OR, [Bring your Dockerfile](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-public-docker-image).
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ By default, Gitpod uses a standard Docker Image called [`workspace-full`](https:
 
 Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust & PHP as well as tools such as Homebrew, Tailscale, Nginx & several more.
 
-If this image does not include the tools you need for your repository, we recommend you use [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3).
-OR, [Bring your Dockerfile](https://www.gitpod.io/blog/docker-in-gitpod).
+If this image does not include the tools you need for your repository, we recommend you start with [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3) and customize it according to your needs. You can refer to this [document to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
+OR, [Bring your Dockerfile](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-public-docker-image).
 
 According to your repository. You can refer to this [documentation to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ If this image does not include the tools you need for your repository, we recomm
 
 OR, [Bring your Dockerfile](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-public-docker-image).
 
-According to your repository. You can refer to this [documentation to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
 
 ### 📷 Images we'll maintain
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ By default, Gitpod uses a standard Docker Image called [`workspace-full`](https:
 
 Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust & PHP as well as tools such as Homebrew, Tailscale, Nginx & several more.
 
-If this image does not include the tools you need for your repository, we recommend you start with [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3) and customize it according to your needs. You can refer to this [document to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
+If this image does not include the tools you need for your repository, we recommend you start with [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3) and,
+
+customize it according to your needs. You can refer to this [document to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
+
 OR, [Bring your Dockerfile](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-public-docker-image).
 
 According to your repository. You can refer to this [documentation to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).

--- a/README.md
+++ b/README.md
@@ -14,14 +14,19 @@ We upgraded to support [dazzle v2](https://github.com/gitpod-io/dazzle) and buil
 ## Summary
 
 - **Operating System**: Ubuntu 20.04.4 LTS
-- **OS Type**: linux
+- **OS Type**: Linux
 - **Architecture**: x86_64
 
 ## Images
 
-By default, Gitpod uses a standard Docker Image called [`workspace-full`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L23) as the foundation for workspaces. Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as tools such as Homebrew, Tailscale, Nginx and several more.
+By default, Gitpod uses a standard Docker Image called [`workspace-full`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L23) as the foundation for workspaces.
 
-If this image does not include the tools you need for your repository, we recommend you to use [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/1ad468e8452aa8a9c14ab5ba4cab10d4f4bb1c90/dazzle.yaml#L3) & [Bring your Dockerfile](https://www.gitpod.io/blog/docker-in-gitpod), according to your repository. You can refer this [documentation to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
+Workspaces started based on this default image come pre-installed with Docker, Nix, Go, Java, Node.js, C/C++, Python, Ruby, Rust & PHP as well as tools such as Homebrew, Tailscale, Nginx & several more.
+
+If this image does not include the tools you need for your repository, we recommend you use [`workspace-base`](https://github.com/gitpod-io/workspace-images/blob/HEAD/dazzle.yaml#L3).
+OR, [Bring your Dockerfile](https://www.gitpod.io/blog/docker-in-gitpod).
+
+According to your repository. You can refer to this [documentation to setup a custom docker image](https://www.gitpod.io/docs/configure/workspaces/workspace-image).
 
 ### 📷 Images we'll maintain
 


### PR DESCRIPTION
## Description
This is a part of gitpod-io/website#2341

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
