### PR TITLE
Latest poetry doesn't support python 3.6

### DIFF
--- a/chunks/lang-python/Dockerfile
+++ b/chunks/lang-python/Dockerfile
@@ -27,10 +27,14 @@ RUN sudo install-packages \
 	&& pip install --no-cache-dir --upgrade \
 	setuptools wheel virtualenv pipenv pylint rope flake8 \
 	mypy autopep8 pep8 pylama pydocstyle bandit notebook \
-	twine \
-	# Install poetry
-	&& curl -sSL https://install.python-poetry.org | python \
-	&& sudo rm -rf /tmp/*
+	twine
+# Install poetry
+RUN if echo $PYTHON_VERSION | grep -q "3.6.*"; then \
+		curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.1.15 python; \
+    else \
+		curl -sSL https://install.python-poetry.org | python; \
+	fi
+RUN sudo rm -rf /tmp/*
 
 COPY --chown=gitpod:gitpod pyenv.d $HOME/.gp_pyenv.d
 COPY --chown=gitpod:gitpod userbase.bash $HOME/.gp_pyenv.d


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

> Poetry 1.2 drops runtime support for Python 2.7, 3.5 and 3.6. Running Poetry on these versions is now untested and unsupported.
https://python-poetry.org/blog/announcing-poetry-1.2.0/#dropping-support-for-python-27-35-and-36-as-runtimes


## How to test
<!-- Provide steps to test this PR -->

Building works fine

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
workspace-images: The workspace image of python 3.6 should use old poetry
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
