### PR TITLE
feat: Persist shell(bash,zsh,fish) histories between workspace reboots

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,10 +50,11 @@ RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
 ENV HOME=/home/gitpod
 WORKDIR $HOME
 # custom Bash prompt
-RUN { echo && echo "PS1='\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$(__git_ps1 \" (%s)\") $ '" ; } >> .bashrc
+RUN RC='\033[0m' GREEN='\033[1;32m' BLUE='\033[1;34m' && \
+    printf '%s\n' PS1="'${GREEN}\u${RC} ${BLUE}\w${RC}\$(__git_ps1 \" (%s)\") $ '" >> "$HOME/.bashrc"
 
 COPY default.gitconfig /etc/gitconfig
-COPY --chown=gitpod:gitpod default.gitconfig /home/gitpod/.gitconfig
+COPY --chown=gitpod:gitpod default.gitconfig "$HOME/.gitconfig"
 
 # configure git-lfs
 RUN git lfs install --system --skip-repo
@@ -63,10 +64,10 @@ USER gitpod
 # use sudo so that user does not get sudo usage info on (the first) login
 RUN sudo echo "Running 'sudo' for Gitpod: success" && \
     # create .bashrc.d folder and source it in the bashrc
-    mkdir -p /home/gitpod/.bashrc.d && \
-    (echo; echo "for i in \$(ls -A \$HOME/.bashrc.d/); do source \$HOME/.bashrc.d/\$i; done"; echo) >> /home/gitpod/.bashrc && \
+    mkdir -p "$HOME/.bashrc.d" && \
+    printf '\n%s\n' 'for s in "$HOME/.bashrc.d/"*; do source "$s"; done 2>/dev/null || :' >> "$HOME/.bashrc" && \
     # create a completions dir for gitpod user
-    mkdir -p /home/gitpod/.local/share/bash-completion/completions
+    mkdir -p "$HOME/.local/share/bash-completion/completions"
 
 # Custom PATH additions
-ENV PATH=$HOME/.local/bin:/usr/games:$PATH
+ENV PATH="$HOME/.local/bin:/usr/games:$PATH"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -71,3 +71,6 @@ RUN sudo echo "Running 'sudo' for Gitpod: success" && \
 
 # Custom PATH additions
 ENV PATH="$HOME/.local/bin:/usr/games:$PATH"
+
+# Install bashrc.d scripts
+COPY --chown=gitpod:gitpod bashrc.d/* $HOME/.bashrc.d

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -65,7 +65,7 @@ USER gitpod
 RUN sudo echo "Running 'sudo' for Gitpod: success" && \
     # create .bashrc.d folder and source it in the bashrc
     mkdir -p "$HOME/.bashrc.d" && \
-    printf '\n%s\n' 'for s in "$HOME/.bashrc.d/"*; do source "$s"; done 2>/dev/null || :' >> "$HOME/.bashrc" && \
+    printf '\n%s\n' 'shopt -s nullglob; for s in "$HOME/.bashrc.d/"*; do source "$s"; done; shopt -u nullglob' >> "$HOME/.bashrc" && \
     # create a completions dir for gitpod user
     mkdir -p "$HOME/.local/share/bash-completion/completions"
 

--- a/base/bashrc.d/persist_hist.sh
+++ b/base/bashrc.d/persist_hist.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+if test -e "$GITPOD_REPO_ROOT" && test ! -v HIST_PERIST_INIT && export HIST_PERIST_INIT=true; then {
+	# Taken from https://github.com/axonasif/dotfiles/blob/34c8663cac2656cdfb0ade40bcf6317c97cc239d/src/config/shell.sh#L7
+	function config::shell::persist_history() {
+		local -r _shell_hist_files=(
+			# Not going to use HISTFILE env var for bash and zsh
+			"$HOME/.bash_history"
+			"$HOME/.zsh_history"
+			"$HOME/.local/share/fish/fish_history"
+		)
+
+		# Use workspace persisted history
+		local _workspace_persist_dir="/workspace/.persist"
+		mkdir -p "$_workspace_persist_dir"
+		local _hist
+		for _hist in "${_shell_hist_files[@]}"; do {
+			mkdir -p "${_hist%/*}"
+			_hist_name="${_hist##*/}"
+			if test ! -e "$_workspace_persist_dir/$_hist_name"; then {
+				printf '' >"$_hist"
+				mv "$_hist" "$_workspace_persist_dir/"
+			}; fi
+			ln -sf "$_workspace_persist_dir/${_hist_name}" "$_hist"
+			unset _hist_name
+		}; done
+	}
+	config::shell::persist_history || :
+}; fi

--- a/base/bashrc.d/persist_hist.sh
+++ b/base/bashrc.d/persist_hist.sh
@@ -3,9 +3,8 @@ if test -e "$GITPOD_REPO_ROOT" && test ! -v HIST_PERIST_INIT && export HIST_PERI
 	# Taken from https://github.com/axonasif/dotfiles/blob/34c8663cac2656cdfb0ade40bcf6317c97cc239d/src/config/shell.sh#L7
 	function config::shell::persist_history() {
 		local -r _shell_hist_files=(
-			# Not going to use HISTFILE env var for bash and zsh
-			"$HOME/.bash_history"
-			"$HOME/.zsh_history"
+			"${HISTFILE:-"$HOME/.bash_history"}"
+			"${HISTFILE:-"$HOME/.zsh_history"}"
 			"$HOME/.local/share/fish/fish_history"
 		)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As the title says. It will only help for workspace reboots but not across workspace(s)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Create a workspace based on `axonasif/workspace-base` from your `.gitpod.yml` (i.e `image: axonasif/workspace-base`)
- Run some random shell commands
- Stop the workspace
- Restart
- Run `history` to check

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
