### PR TITLE
chore: bump nix version

### DIFF
--- a/chunks/tool-nix/chunk.yaml
+++ b/chunks/tool-nix/chunk.yaml
@@ -1,5 +1,5 @@
 variants:
-  - name: "2.6.0"
+  - name: "2.11.0"
     args:
-      NIX_VERSION: 2.6.0
+      NIX_VERSION: 2.11.0
       NIX_CONFIG: "experimental-features = nix-command flakes"

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -34,7 +34,7 @@ combiner:
         - lang-rust
         - tool-brew
         - tool-nginx
-        - tool-nix:2.6.0
+        - tool-nix:2.11.0
     - name: full-vnc
       ref:
       - full
@@ -49,7 +49,7 @@ combiner:
       ref:
       - base
       chunks:
-        - tool-nix:2.6.0
+        - tool-nix:2.11.0
     - name: node
       ref:
       - base

--- a/tests/tool-nix.yaml
+++ b/tests/tool-nix.yaml
@@ -8,4 +8,4 @@
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("2.6.0") != -1
+  - stdout.indexOf("2.11.0") != -1


### PR DESCRIPTION
Upgraded Nix Version from 2.6 -> 2.11
Latest Release Notes ([read here](https://nixos.org/manual/nix/stable/release-notes/rl-2.11.html))

---

> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>