### PR TITLE
refactor: python_hook.bash

### DIFF
--- a/chunks/lang-python/python_hook.bash
+++ b/chunks/lang-python/python_hook.bash
@@ -18,7 +18,7 @@ function pyenv_gitpod_init() {
 				exec >>"/tmp/.${FUNCNAME[0]}.log" && exec 2>&1
 				set -eu
 				local lockfile="/tmp/.vscs_add.lock"
-				trap 'rm -f $lockfile $tmp_file || :;:' ERR SIGINT RETURN
+				trap 'rm -f $lockfile $tmp_file || :;:' ERR SIGINT RETURN EXIT
 				while test -e "$lockfile" && sleep 0.2; do {
 					continue
 				}; done


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This time it will handle errors properly and will not log anything on the attached pty but write to `/tmp/.vscode::add_settings.log` file if any error occurs. Will always return true on the parent shell process.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
~~Reverts the change that inconsistently causes [this](https://gitpod.slack.com/archives/C01KGM9BH54/p1663747428135699)
It was mainly due to the parent directory not being present before the file creation. But since https://github.com/gitpod-io/gitpod/issues/13029 is being worked out, so we no longer need to fix it here or handle this.~~ In the future we can get rid of this function and use a native built-in gitpod method once we have.

## How to test
<!-- Provide steps to test this PR -->

```bash
docker build --build-arg base=gitpod/workspace-base --build-arg PYTHON_VERSION=3.8.13 -t python chunks/lang-python

# The `$HOME/.bashrc/*-python` script relies on the existence of $GITPOD_REPO_ROOT as it expects a real-workspace, so we need GITPOD_REPO_ROOT to be there otherwise it won't make any change to the env.

# Test without an existing settings.json
rm -f /workspace/.vscode-remote/data/Machine/settings.json && docker run -v /workspace:/workspace -e GITPOD_REPO_ROOT -it python

# Test with an existing settings.json
printf '{ "%s": "%s" }\n' one value > /workspace/.vscode-remote/data/Machine/settings.json && docker run -v /workspace:/workspace -e GITPOD_REPO_ROOT -it python

# Test with a settings.json containing syntax errors
printf '{ "%s" "%s" \n' one value > /workspace/.vscode-remote/data/Machine/settings.json && docker run -v /workspace:/workspace -e GITPOD_REPO_ROOT -it python

# To further verify, run:
cat /workspace/.vscode-remote/data/Machine/settings.json ~/.vscode-server/data/Machine/settings.json
# And observe that it's a valid json file with `python` settings added.

# Check log file
cat "/tmp/.vscode::add_settings"
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
