### PR TITLE
update go to v1.19.1 in workspace-full

### DIFF
--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -26,7 +26,7 @@ combiner:
       chunks:
         - lang-c
         - lang-clojure
-        - lang-go:1.19
+        - lang-go:1.19.1
         - lang-java:11
         - lang-node:16
         - lang-python:3.8
@@ -45,7 +45,7 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-go:1.19
+        - lang-go:1.19.1
     - name: nix
       ref:
       - base


### PR DESCRIPTION
## Description
Update workspace-full image to use go 1.19.1.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
