### PR TITLE
feat: make user aware of the current workspace-image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -71,3 +71,6 @@ RUN sudo echo "Running 'sudo' for Gitpod: success" && \
 
 # Custom PATH additions
 ENV PATH=$HOME/.local/bin:/usr/games:$PATH
+
+# Install bashrc.d
+COPY --chown=gitpod:gitpod bashrc.d/ $HOME/.bashrc.d

--- a/base/bashrc.d/900-ws-info
+++ b/base/bashrc.d/900-ws-info
@@ -1,0 +1,137 @@
+(
+	set -eu
+	function remove_self() {
+		# Remove the hook file, because we no longer need it to be loaded.
+		if [[ "${BASH_SOURCE[0]}" =~ \.bashrc.d/[0-9]+- ]]; then {
+			rm -f "${BASH_SOURCE[0]}"
+		} fi
+	}
+	lockfile=/tmp/.wsinfo_lck
+	trap '{ remove_self; rm -f "$lockfile"; } || :' EXIT ERR
+
+	# Return early if user opted out
+	if test "${GITPOD_DISABLE_WORKSPACE_IMAGE_INFO:-false}" == true; then {
+		exit 0 # This is a subshell
+	} fi
+
+	if test ! -e "$lockfile"; then {
+		remove_self
+		printf '' > "$lockfile"
+
+		# The supervisor creates the task terminals, supervisor calls BASH from `/bin/bash` instead of the realpath `/usr/bin/bash`
+		# So we will only print the info once, on a non-task terminal that the user created manually
+		if ! [ "$BASH" == /bin/bash ] || ! [ "$PPID" == "$(pgrep -f "supervisor run" | head -n1)" ]; then {
+
+			# Get image source
+			gitpod_yml_path="$GITPOD_REPO_ROOT/.gitpod.yml"
+			if test ! -e "$gitpod_yml_path"; then {
+				: "workspace-full"
+			} elif res="$(awk '/image:/,/file:/' "$gitpod_yml_path" | awk '{ if (NR==2) { print $2; exit } }')" && test -n "${res:-}"; then {
+				if res="$(awk '{ if ($1 ~ /^FROM/) { print  $2; exit } }' "$GITPOD_REPO_ROOT/$res")" && test -n "${res:-}"; then {
+					: "${res#*/}"
+				} else {
+					: "workspace-full"
+				} fi
+			} elif res="$(sed -n 's/^image: //p' "$gitpod_yml_path")" && test -n "${res:-}"; then {
+				: "${res#*/}"
+			} else {
+				: "workspace-full"
+			} fi
+			image_source="$_"
+
+			wsimgs_repo_root="https://github.com/gitpod-io/workspace-images/tree/main"
+			username="${GITPOD_GIT_USER_NAME:-"gitpodder"}"
+			published_wsimgs=(
+				"workspace-base"
+				"workspace-c"
+				"workspace-cojure"
+				"workspace-elixir"
+				"workspace-go"
+				"workspace-java"
+				"workspace-node"
+				"workspace-python"
+				"workspace-ruby"
+				"workspace-rust"
+				"workspace-nix"
+				"workspace-mysql"
+			)
+			published_wsimgs_withfull=(
+				"${published_wsimgs[@]}"
+				"workspace-full"
+				"workspace-full-vnc"
+			)
+
+			# Check if a recognized image
+			if ! [[ "${published_wsimgs_withfull[*]}" =~ (^| )${image_source}($| ) ]]; then {
+				exit 0;
+			} fi
+
+			# Colors
+			readonly RC='\033[0m' RED='\033[0;31m' BRED='\033[1;31m' GRAY='\033[1;30m'
+			readonly BLUE='\033[0;34m' BBLUE='\033[1;34m' CYAN='\033[0;34m' BCYAN='\033[1;34m'
+			readonly WHITE='\033[1;37m' GREEN='\033[0;32m' BGREEN='\033[1;32m' YELLOW='\033[1;33m'
+			readonly PURPLE='\033[0;35m' BPURPLE='\033[1;35m' ORANGE='\033[0;33m'
+
+
+			# Header
+			printf "Hello $username 👋, your workspace is based on the ${BBLUE}%s${RC} docker image.\n\n" \
+				"${image_source}"
+
+			# Body
+			case "${image_source}" in
+				"workspace-base")
+					printf '%s\n\n' "⚡️ This is the most minimal image, used for bootstrapping bigger images. It includes:";
+					printf '\t✨ %s\n' \
+						'build-essential' \
+						'docker' \
+						'shells: bash, zsh and fish' \
+						'git' \
+						'htop, jq, ripgrep' \
+						'sudo' \
+						'CLI editors such as nano and vim' \
+						'tailscale' \
+						'And some other must-have tools'
+					: "base"
+				;;
+				"workspace-full")
+					printf '%s\n' "🔋 This is the most loaded image with tons of common tooling installed." \
+						"🎗  It's a compilation of the following images:"
+					printf '\n'
+					printf '\t💥 %s, %s\n' "${published_wsimgs[@]}"
+
+					: "chunks"
+				;;
+				"workspace-full-vnc")
+					printf '%s\n' '🖥  This image is mainly useful for GUI application development where you need a display server.'
+					printf "🔋 It's based on ${BGREEN}%s${RC}, it additionally contains:\n\n" 'workspace-full'
+					printf '\t🍭 %s\n' \
+						'tigervnc server' \
+						'noVNC viewer' \
+						'google-chrome' \
+						'xfce4 desktop environment' \
+						'"gp-vncsession" script'
+
+					: "chunks/tool-vnc"
+				;;
+				*)
+					if [[ "${published_wsimgs[*]}" =~ (^| )${image_source}($| ) ]]; then {
+						chunk_name="${image_source#*-}" && chunk_name="${chunk_name^}"
+						printf "⚙️  This is mainly optimized for ${BGREEN}%s${RC}, and is likely based on ${GRAY}workspace-base${RC}.\n" "$chunk_name"
+
+						# tool vs lang
+						if [[ "$image_source" =~ -nix|-mysql ]]; then {
+							: "chunks/tool-${image_source#*-}"
+						} else {
+							: "chunks/lang-${image_source#*-}"
+						} fi
+					} fi
+				;;
+			esac
+
+			# Footer
+			printf "\n📚 Learn more about ${image_source} at ${ORANGE}%s${RC}\n" "${wsimgs_repo_root}/$_"
+
+			# TODO: Observe if people are wanting to disable this one-time info. There likely won't be many requests.
+		} fi
+	} fi
+) 2>/dev/null


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Show the current workspace-image info only when the user is using an official gitpod image. (by parsing `.gitpod.yml` and the dockerfile if-exists)
- Include a link to the source code of the current workspace-image that also contains a dedicated `README.md`
- Once every session whenever someone creates a new terminal manually. After first execution, the script removes itself.
- Will avoid task terminals, because showing there would not be very visible most of the time.
- User can completely disable this by adding `GITPOD_DISABLE_WORKSPACE_IMAGE_INFO=true` at https://gitpod.io/variables with `*/*` as the scope.

|base|full|
|---|---|
|<img width="805" alt="Screenshot 2022-10-09 at 3 59 42 PM" src="https://user-images.githubusercontent.com/39482679/194750444-6caf294e-250d-437c-b550-8626b716321d.png">|<img width="822" alt="Screenshot 2022-10-09 at 4 04 05 PM" src="https://user-images.githubusercontent.com/39482679/194750626-19228832-2ff3-49ab-9346-7507532bd26f.png">|
|full-vnc|other|
|<img width="922" alt="Screenshot 2022-10-09 at 4 01 14 PM" src="https://user-images.githubusercontent.com/39482679/194750513-c2bf2e18-8d6b-4edc-809e-9a31860d5bb5.png">|<img width="911" alt="Screenshot 2022-10-09 at 4 02 09 PM" src="https://user-images.githubusercontent.com/39482679/194750564-29af9864-8f4f-4876-b1a5-09478079788d.png">|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates with https://github.com/gitpod-io/gitpod/issues/10683

Next steps:
- [ ] Add README to each `chunk/*/` dir explaining what this chunk contains and if there's something special to be aware of.
- [ ] Add README to `base/` dir to explain how the base image sets up the required things for a minimal but functional docker image. In case someone wants to create their own minimal base image of a different distro (i.e Arch or Fedora)
- [ ] Add workspace-images changelog on these READMEs
- [ ] We could repurpose the READMEs for https://github.com/gitpod-io/dazzle/pull/56 when it's used here.

So that the user can click the scoped link from their terminal to read these READMEs

## How to test
<!-- Provide steps to test this PR -->
- Open this PR on Gitpod.
- Run:
```bash
docker build -t base base/ && docker run -v /workspace:/workspace -e GITPOD_REPO_ROOT -e GITPOD_GIT_USER_NAME -it base
```
- Change the `image` values on `.gitpod.yml` and rerun the above command to get different info. Or you can remove `.gitpod.yml` and it will assume the default image, which is `workspace-full`. You may change the image name on `.gitpod.Dockerfile` as well.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Current workspace-image info is shown once every session on the terminal
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
