### PR TITLE
Copy images using OCI manifests

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -72,7 +72,7 @@ jobs:
           IMAGES=$(cat .github/promote-images.yml | yq '."europe-docker.pkg.dev/gitpod-artifacts/docker-dev"."images-by-tag-regex"|keys[]' -r)
           for IMAGE in $IMAGES;
           do
-            sudo skopeo copy \
+            sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/$IMAGE:latest \
             docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest
           done

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -107,13 +107,13 @@ jobs:
           COPY_JOBS_PIDS=""
           for IMAGE_TAG in $IMAGE_TAGS;
           do
-            sudo skopeo copy \
+            sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:${{ env.TIMESTAMP_TAG }} &
 
             COPY_JOBS_PIDS="$COPY_JOBS_PIDS $!"
 
-            sudo skopeo copy \
+            sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:latest &
 


### PR DESCRIPTION
## Description

Use OCI manifests for the publication of the images instead of docker.

The goal here is to enable the research of lazy snapshotters.

## How to test
- Use oci-tool to verify the published images use OCI instead docker media types

