### PR TITLE
Fix tailscale ssh

### DIFF
--- a/chunks/tool-tailscale/Dockerfile
+++ b/chunks/tool-tailscale/Dockerfile
@@ -4,13 +4,14 @@ FROM ${base}
 USER root
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 
 RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key add - \
     && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
     && apt-get update \
     && apt-get install -y tailscale \
-    && rm /etc/apt/sources.list.d/tailscale.list
+    && rm /etc/apt/sources.list.d/tailscale.list \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
 
 ## "apt-key add" adds a PGP to a joint file which does not make it through dazzle.
 ## If we didn't remove the source list entry above, subsequent apt-get operations would break.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This way users do not have DNS issues "out of the box".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/website/pull/2908

## How to test
<!-- Provide steps to test this PR -->
After this is merged to main, we'll be able to create a workspace using timestamped image.

Beforehand, you may run: `./build-chunk.sh -c tool-tailscale`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use tailscale 1.32 or later and avoid DNS issues
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
