### PR TITLE
fix(tool-postgresql): Race condition

### DIFF
--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -18,15 +18,11 @@ RUN PGDATA="${PGDATA//\/workspace/$HOME}" \
  && initdb -D $PGDATA \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" start\n' > ~/.pg_ctl/bin/pg_start \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
- && chmod +x ~/.pg_ctl/bin/* \
- && printf '%s\n' '# Auto-start PostgreSQL server' \
-                  '(' \
-                  "mkdir \$PGWORKSPACE 2>/dev/null || exit 0; test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \
-                  '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' \
-                  ') & disown' > ~/.bashrc.d/200-postgresql-launch
+ && chmod +x ~/.pg_ctl/bin/*
 ENV PATH="$HOME/.pg_ctl/bin:$PATH"
 ENV DATABASE_URL="postgresql://gitpod@localhost"
 ENV PGHOSTADDR="127.0.0.1"
 ENV PGDATABASE="postgres"
+COPY --chown=gitpod:gitpod postgresql-hook.bash $HOME/.bashrc.d/200-postgresql-launch
 
 USER gitpod

--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -20,8 +20,10 @@ RUN PGDATA="${PGDATA//\/workspace/$HOME}" \
  && printf '#!/bin/bash\npg_ctl -D $PGDATA -l ~/.pg_ctl/log -o "-k ~/.pg_ctl/sockets" stop\n' > ~/.pg_ctl/bin/pg_stop \
  && chmod +x ~/.pg_ctl/bin/* \
  && printf '%s\n' '# Auto-start PostgreSQL server' \
-                  "test ! -e \$PGWORKSPACE && test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \
-                  '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' > ~/.bashrc.d/200-postgresql-launch
+                  '(' \
+                  "mkdir \$PGWORKSPACE 2>/dev/null || exit 0; test -e ${PGDATA%/data} && mv ${PGDATA%/data} /workspace" \
+                  '[[ $(pg_ctl status | grep PID) ]] || pg_start > /dev/null' \
+                  ') & disown' > ~/.bashrc.d/200-postgresql-launch
 ENV PATH="$HOME/.pg_ctl/bin:$PATH"
 ENV DATABASE_URL="postgresql://gitpod@localhost"
 ENV PGHOSTADDR="127.0.0.1"

--- a/chunks/tool-postgresql/postgresql-hook.bash
+++ b/chunks/tool-postgresql/postgresql-hook.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Auto-start PostgreSQL server
+(
+	if mkdir /tmp/.pgsql_lock 2>/dev/null; then {
+		target="${PGWORKSPACE}"
+		source="${target//\/workspace/$HOME}"
+
+		if test -e "$source"; then {
+
+			if test ! -e "$target"; then {
+				mv "$source" "$target"
+			}; fi
+
+			if ! [[ "$(pg_ctl status)" =~ PID ]]; then {
+				pg_start >/dev/null
+				trap "pg_stop" TERM EXIT
+				exec {sfd}<> <(:)
+				until read -r -t 3600 -u $sfd; do continue; done
+			}; fi
+
+		}; fi
+	}; fi
+) &
+disown

--- a/chunks/tool-postgresql/postgresql-hook.bash
+++ b/chunks/tool-postgresql/postgresql-hook.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Auto-start PostgreSQL server
+set +m
 (
 	if mkdir /tmp/.pgsql_lock 2>/dev/null; then {
 		target="${PGWORKSPACE}"
@@ -26,3 +27,4 @@
 	}; fi
 ) &
 disown
+set -m

--- a/chunks/tool-postgresql/postgresql-hook.bash
+++ b/chunks/tool-postgresql/postgresql-hook.bash
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Auto-start PostgreSQL server
-set +m
 (
 	if mkdir /tmp/.pgsql_lock 2>/dev/null; then {
 		target="${PGWORKSPACE}"
@@ -24,7 +23,5 @@ set +m
 			}; fi
 
 		}; fi
-	}; fi
-) &
-disown
-set -m
+	}; fi &
+)

--- a/chunks/tool-postgresql/postgresql-hook.bash
+++ b/chunks/tool-postgresql/postgresql-hook.bash
@@ -12,9 +12,13 @@
 			}; fi
 
 			if ! [[ "$(pg_ctl status)" =~ PID ]]; then {
-				pg_start >/dev/null
+				printf 'INFO: %s\n' "Executing command: pg_start"
+				pg_start
 				trap "pg_stop" TERM EXIT
 				exec {sfd}<> <(:)
+				printf 'INFO: %s\n' \
+					"Please create another terminal" \
+					"this one is monitoring postgres server for gracefully shutting down when needed"
 				until read -r -t 3600 -u $sfd; do continue; done
 			}; fi
 

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -60,7 +60,7 @@
     - status == 0
 
 - desc: "VSCode Python settings are correctly applied"
-  entrypoint: [sh, -c]
-  command: [export GITPOD_REPO_ROOT=/workspace/test; for sj in "$HOME/.vscode-server/data/Machine/settings.json" "/workspace/.vscode-remote/data/Machine/settings.json"; do mkdir -p $(dirname "$sj") "$GITPOD_REPO_ROOT" && touch "$sj" && bash -lic 'true' && if ! grep -q 'python' "$sj"; then exit 1; fi; done]
+  entrypoint: [env, GITPOD_REPO_ROOT=/workspace/test, bash, -lic]
+  command: [rm /tmp/.vscs_add.lock; for sj in "$HOME/.vscode-server/data/Machine/settings.json" "/workspace/.vscode-remote/data/Machine/settings.json"; do mkdir -p $(dirname "$sj") "$GITPOD_REPO_ROOT" && touch "$sj" && bash -lic 'true' && if ! grep -q 'python' "$sj"; then exit 1; fi; done]
   assert:
     - status == 0

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -60,7 +60,7 @@
     - status == 0
 
 - desc: "VSCode Python settings are correctly applied"
-  entrypoint: [bash, -c]
-  command: [export GITPOD_REPO_ROOT=/workspace/test; for sj in "$HOME/.vscode-server/data/Machine/settings.json" "/workspace/.vscode-remote/data/Machine/settings.json"; do mkdir -p $(dirname "$sj") "$GITPOD_REPO_ROOT" && touch "$sj" && bash -cli 'exit' && if ! grep -q 'python' "$sj"; then exit 1; fi; done]
+  entrypoint: [sh, -c]
+  command: [export GITPOD_REPO_ROOT=/workspace/test; for sj in "$HOME/.vscode-server/data/Machine/settings.json" "/workspace/.vscode-remote/data/Machine/settings.json"; do mkdir -p $(dirname "$sj") "$GITPOD_REPO_ROOT" && touch "$sj" && bash -lic 'true' && if ! grep -q 'python' "$sj"; then exit 1; fi; done]
   assert:
     - status == 0

--- a/tests/tool-postgresql.yaml
+++ b/tests/tool-postgresql.yaml
@@ -6,7 +6,7 @@
   - stdout.indexOf("(PostgreSQL) 12") != -1
 - desc: it should serve postgres
   entrypoint: [bash, -i, -c]
-  command: [psql -l]
+  command: [until pg_ctl status; do sleep 1; done && psql -l]
   assert:
   - stdout.indexOf("List of databases") != -1
   - status == 0

--- a/tests/tool-postgresql.yaml
+++ b/tests/tool-postgresql.yaml
@@ -6,7 +6,7 @@
   - stdout.indexOf("(PostgreSQL) 12") != -1
 - desc: it should serve postgres
   entrypoint: [bash, -i, -c]
-  command: [sleep 5; psql -l]
+  command: [for _ in $(seq 10); do sleep 0.5; pg_ctl status && pgok=0; done && test -v pgok && psql -l]
   assert:
   - stdout.indexOf("List of databases") != -1
   - status == 0

--- a/tests/tool-postgresql.yaml
+++ b/tests/tool-postgresql.yaml
@@ -6,7 +6,7 @@
   - stdout.indexOf("(PostgreSQL) 12") != -1
 - desc: it should serve postgres
   entrypoint: [bash, -i, -c]
-  command: [until pg_ctl status; do sleep 1; done && psql -l]
+  command: [sleep 5; psql -l]
   assert:
   - stdout.indexOf("List of databases") != -1
   - status == 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
More context [here](https://gitpod.slack.com/archives/C01RC164G48/p1667306470780959) (internal - slack).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/432
- Parallel starts.
- Autostop server on workspace shutdown.
- Faster shell startup by using subprocess (top: before, down: after)
<img width="1193" alt="Screenshot 2022-11-02 at 7 08 52 PM" src="https://user-images.githubusercontent.com/39482679/199574263-a8bf8d4d-49fd-4191-a056-d41aaf3088c9.png">


## How to test
<!-- Provide steps to test this PR -->
- Workspace: https://gitpod.io/#imagebuild/https://github.com/axonasif/test/tree/postgresql-test
- To test in existing workspace with race condition simulation:
```bash
docker run -it axonasif/postgresql:latest sh -c 'for _ in 1 2 3 4 5; do bash -lic "true" & done; wait'
```
- Ensure no postgres server related errors are found on the terminal and the server is running:
```bash
docker run -it axonasif/postgresql:latest sh -c 'for _ in 1 2 3 4 5; do bash -lic "true" & done; wait; sleep 3; ps -fax | grep postgres'
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
