### PR TITLE
Revert "Get dotnet working properfy on shiftfs." (should no longer be needed)

### DIFF
--- a/chunks/tool-dotnet/Dockerfile
+++ b/chunks/tool-dotnet/Dockerfile
@@ -10,14 +10,3 @@ ENV TRIGGER_REBUILD=1
 RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.200 --install-dir /home/gitpod/dotnet
 ENV DOTNET_ROOT=/home/gitpod/dotnet
 ENV PATH=/home/gitpod/dotnet:$PATH
-
-# TODO(toru): Remove this hack when the kernel bug is resolved.
-#             ref. https://github.com/gitpod-io/gitpod/issues/8901
-RUN bash \
-    && { echo 'if [ ! -z $GITPOD_REPO_ROOT ]; then'; \
-        echo '\tCONTAINER_DIR=$(awk '\''{ print $6 }'\'' /proc/self/maps | grep ^\/run\/containerd | head -n 1 | cut -d '\''/'\'' -f 1-6)'; \
-        echo '\tif [ ! -z $CONTAINER_DIR ]; then'; \
-        echo '\t\t[[ ! -d $CONTAINER_DIR ]] && sudo mkdir -p $CONTAINER_DIR && sudo ln -s / $CONTAINER_DIR/rootfs'; \
-        echo '\tfi'; \
-        echo 'fi'; } >> /home/gitpod/.bashrc.d/110-dotnet
-RUN chmod +x /home/gitpod/.bashrc.d/110-dotnet


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This reverts commit b76d3c5e97af017216fc238ad3b22cec964faa46. It should no longer be needed to persist to `/workspace` with the workaround.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related: https://github.com/gitpod-io/gitpod/issues/8901

## How to test
<!-- Provide steps to test this PR -->
1. [Start this](https://gitpod.io#snapshot/4cda517f-7aa5-42bc-80dd-12d850031744) Gitpod, which is from gitpod.new, which uses `workspace-full` (and [does not include dotnet chunk](https://github.com/gitpod-io/workspace-images/blob/fc69ed9e68551b872fdc91db31c81ec124cff9df/dazzle.yaml#L23-L37))
2. Add dotnet support
```
mkdir -p /home/gitpod/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.200 --install-dir /home/gitpod/dotnet
DOTNET_ROOT=/home/gitpod/dotnet
PATH=/home/gitpod/dotnet:$PATH
dotnet dev-certs https
```
3. Copy `program.cs` and `dotnetcore.csproj` from https://github.com/gitpod-io/template-dotnet-core-cli-csharp into your workspace, and try running the built program
```
dotnet restore
dotnet build
gitpod /workspace/empty (main) $ dotnet run
Hello World!
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
