### PR TITLE
feat(base): autoload bash env for other shells

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -59,6 +59,13 @@ COPY --chown=gitpod:gitpod default.gitconfig /home/gitpod/.gitconfig
 # configure git-lfs
 RUN git lfs install --system --skip-repo
 
+# Autoload .bashrc.d for other SHELLs (fish and zsh)
+RUN mkdir -m 755 -p /usr/share/fish/vendor_conf.d /etc/zsh \
+    && printf 'source %s\n' /etc/zsh/autoload_bash.zsh >> /etc/zsh/zshrc
+COPY fish/autoload_bash.fish /usr/share/fish/vendor_conf.d
+COPY zsh/autoload_bash.zsh /etc/zsh
+RUN chmod 755 /etc/zsh/autoload_bash.zsh && touch $HOME/.zshrc
+
 ### Gitpod user (2) ###
 USER gitpod
 # use sudo so that user does not get sudo usage info on (the first) login

--- a/base/fish/autoload_bash.fish
+++ b/base/fish/autoload_bash.fish
@@ -1,0 +1,6 @@
+#!/usr/bin/env fish
+if ! test -n "$AUTOLOAD_BASH_INJ"
+    set -gx AUTOLOAD_BASH_INJ true
+    exec bash -lic 'exec fish'
+end
+set -gu AUTOLOAD_BASH_INJ

--- a/base/zsh/autoload_bash.zsh
+++ b/base/zsh/autoload_bash.zsh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if test ! -v AUTOLOAD_BASH_INJ; then
+	export AUTOLOAD_BASH_INJ=true
+	exec bash -lic 'exec zsh'
+fi
+unset AUTOLOAD_BASH_INJ


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds startup scripts specific to fish and zsh to autoload the `bash` environment variables within their sessions without altering the user configuration (i.e. dotfiles)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10105

## How to test
<!-- Provide steps to test this PR -->
<img width="444" alt="Screenshot 2022-11-25 at 3 36 29 PM" src="https://user-images.githubusercontent.com/39482679/203952195-df74cada-4a0e-4572-9627-0fb892018464.png">

Open this PR on Gitpod.

Build and run:
```bash
cd base
docker build -t base . && docker run -it base
```
We will land in a `bash` shell. Now we can create a script inside `~/.bashrc.d` from the bash session and then switch to another shell to test if it picked it up.

```bash
echo 'export TESTVAR=hello' > ~/.bashrc.d/testing

# Switch to fish
fish

# Check the variable
echo $TESTVAR

# Exit
exit

# Switch to zsh
zsh

# Check
echo $TESTVAR

# Exit
exit

# We'll be back on `bash` (however, it didn't pick up `~/.bashrc.d/testing`, because it was created during the session)
echo $TESTVAR # will be empty
# let's check in `env` as well
env | grep TESTVAR # will be empty

# Now let's reload bash session
exec bash -l

# Now it should be available on bash as well
env | grep TESTVAR
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
