### PR TITLE
Use Self-Hosted Actions Runner

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,20 +38,20 @@ jobs:
       - name: 🗄️ Force Save Registry Cache Per Sha
         uses: actions/cache@v3
         with:
-          path: ~/registry
+          path: registry
           key: ${{ runner.os }}-pull-request-cache-${{ github.sha }}
 
       - name: 🗄️ Restore Registry Cache
         uses: actions/cache@v3
         with:
-          path: ~/registry
+          path: registry
           key: ${{ runner.os }}-pull-request-cache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-pull-request-cache-
 
       - name: 📦 Setup local registry
         run: |
-          docker run -it --detach --publish 5000:5000 --volume ~/registry:/var/lib/registry registry:2
+          docker run -it --detach --publish 5000:5000 --volume registry:/var/lib/registry registry:2
 
       - name: 🔨 Dazzle build
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: 📥 Checkout workspace-images
         uses: actions/checkout@v3

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -13,7 +13,7 @@ jobs:
   # Click New environment, set the name production, and click Configure environment.
   # Check the "Required reviewers" box and enter at least one user or team name.
   sync:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: "production"
     permissions:
       contents: "read"


### PR DESCRIPTION
## Description
This PR reduces the build time from ~3h to ~2h by running it on a self-hosted action runner (https://github.com/gitpod-io/ops/pull/7395)

This PR also changes the path of the local registries work dir from `~/registry` to `registry` to move it from an overlay-fs-backed volume to a hostpath-backed volume (the runners' workdir).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5484

## How to test
<!-- Provide steps to test this PR -->
* Run the build job on this PR.
* I did not test the job that runs on `main`. Not sure what's the best way to do this because as part of the job, images are published. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
