### PR TITLE
fix(lang-golang): Set GOBIN env var

### DIFF
--- a/chunks/lang-go/Dockerfile
+++ b/chunks/lang-go/Dockerfile
@@ -10,7 +10,8 @@ ENV TRIGGER_REBUILD=1
 ENV GO_VERSION=${GO_VERSION}
 ENV GOPATH=$HOME/go-packages
 ENV GOROOT=$HOME/go
-ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+ENV GOBIN=$GOROOT/bin
+ENV PATH=$GOBIN:$GOPATH/bin:$PATH
 RUN curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xzs && \
 # install VS Code Go tools for use with gopls as per https://github.com/golang/vscode-go/blob/master/docs/tools.md
 # also https://github.com/golang/vscode-go/blob/27bbf42a1523cadb19fad21e0f9d7c316b625684/src/goTools.ts#L139


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The `GOBIN` environment variable is not set at the moment, which makes it so installing Go tools with `go install` are not working properly. This PR sets the env var's value to `/home/gitpod/go/bin`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
GOBIN evironment variable is now set to $GOROOT/bin
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

> Does this PR require updates to the documentation at www.gitpod.io/docs?

I'm not sure