### PR TITLE
Fix failed test for rust chunk

### DIFF
--- a/tests/lang-rust.yaml
+++ b/tests/lang-rust.yaml
@@ -33,8 +33,8 @@
   command: [cargo add --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo-add") != -1 ||
-    stderr.indexOf("cargo-add") != -1
+  - stdout.indexOf("cargo add") != -1 ||
+    stderr.indexOf("cargo add") != -1
 - desc: it should have workspaces subcommand for cargo
   entrypoint: [bash, -i, -c]
   command: [cargo workspaces --help]

--- a/tests/lang-rust.yaml
+++ b/tests/lang-rust.yaml
@@ -26,19 +26,13 @@
   command: [cargo watch --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo-watch") != -1 ||
-    stderr.indexOf("cargo-watch") != -1
 - desc: it should have one of edit(add, rm, upgrade, set-version) subcommand(s) for cargo
   entrypoint: [bash, -i, -c]
   command: [cargo add --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo add") != -1 ||
-    stderr.indexOf("cargo add") != -1
 - desc: it should have workspaces subcommand for cargo
   entrypoint: [bash, -i, -c]
   command: [cargo workspaces --help]
   assert:
   - status == 0
-  - stdout.indexOf("cargo-workspaces") != -1 ||
-    stderr.indexOf("cargo-workspaces") != -1


### PR DESCRIPTION
## Description
I broke the tests for the rust-lang chunk in #996 . This PR adjusts the failing test, so it passes again.

Previously we tested that `cargo add --help` outputs the string `cargo-add`, but it does not do that anymore with the latest rust version. I adjusted it to test for `cargo add` instead. The test should probably be removed, because if `cargo add --help` exits with code 0 the subcommand exists.
