### PR TITLE
feat: add devenv

### DIFF
--- a/chunks/tool-nix/Dockerfile
+++ b/chunks/tool-nix/Dockerfile
@@ -9,7 +9,7 @@ ENV NIX_VERSION=${NIX_VERSION}
 USER root
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 
 RUN addgroup --system nixbld \
   && adduser gitpod nixbld \
@@ -40,3 +40,8 @@ RUN mkdir -p /home/gitpod/.config/direnv \
   && . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
   && nix-env -i direnv \
   && direnv hook bash >> /home/gitpod/.bashrc
+  
+# Install devenv
+RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
+  && cachix use devenv \
+  && nix-env -if https://github.com/cachix/devenv/tarball/v0.5


### PR DESCRIPTION
## Description
[Devenv](https://devenv.sh/) is a fast, reproduceable developer environment based on Nix, allows configuring your environment with Nix.

## How to test

```
devenv init
```

Add as example:

```nix
languages.javascript.enable = true;
languages.javascript.package = pkgs.nodejs-16_x;
```

Direnv should automatically reload, and you have node 16 (which node). All options are documented here https://devenv.sh/reference/options/