### PR TITLE
[tests] disable brittle python tests

### DIFF
--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -41,23 +41,24 @@
     - status == 0
     - stdout.indexOf("/workspace/.pyenv_mirror") != -1
 
-- desc: "`pyenv install <ver>` should use $HOME/.pyenv/versions/ for imagebuild env"
-  entrypoint: [bash, -c]
-  command:
-    [
-      ver=3.9.0; pyenv install $ver && test -e $PYENV_ROOT/versions/$ver,
-    ]
-  assert:
-    - status == 0
+# https://github.com/gitpod-io/workspace-images/issues/1000
+# - desc: "`pyenv install <ver>` should use $HOME/.pyenv/versions/ for imagebuild env"
+#   entrypoint: [bash, -c]
+#   command:
+#     [
+#       ver=3.9.0; pyenv install $ver && test -e $PYENV_ROOT/versions/$ver,
+#     ]
+#   assert:
+#     - status == 0
 
-- desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
-  entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
-  command:
-    [
-      ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod,
-    ]
-  assert:
-    - status == 0
+# - desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
+#   entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
+#   command:
+#     [
+#       ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod,
+#     ]
+#   assert:
+#     - status == 0
 
 - desc: "VSCode Python settings are correctly applied"
   entrypoint: [env, GITPOD_REPO_ROOT=/workspace/test, bash, -lic]


### PR DESCRIPTION
These tests sometimes pass, but often cycle forever, causing builds to take too long or timeout/fail.

Related: https://github.com/gitpod-io/workspace-images/issues/1000