### PR TITLE
Create image for python 3.11 and remove EOL python 3.6

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -19,6 +19,7 @@
     workspace-python-3.8: "20.*"
     workspace-python-3.9: "20.*"
     workspace-python-3.10: "20.*"
+    workspace-python-3.11: "20.*"
     workspace-ruby-2: "20.*"
     workspace-ruby-3: "20.*"
     workspace-ruby-3.0: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -16,6 +16,7 @@ sync:
     - python-3.8
     - python-3.9
     - python-3.10
+    - python-3.11
     - ruby-2
     - ruby-3
     - ruby-3.0

--- a/chunks/lang-python/chunk.yaml
+++ b/chunks/lang-python/chunk.yaml
@@ -1,7 +1,4 @@
 variants:
-  - name: "3.6"
-    args:
-      PYTHON_VERSION: 3.6.15
   - name: "3.7"
     args:
       PYTHON_VERSION: 3.7.13

--- a/chunks/lang-python/chunk.yaml
+++ b/chunks/lang-python/chunk.yaml
@@ -14,3 +14,6 @@ variants:
   - name: "3.10"
     args:
       PYTHON_VERSION: 3.10.6
+  - name: "3.11"
+    args:
+      PYTHON_VERSION: 3.11.1

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -88,6 +88,11 @@ combiner:
       - base
       chunks:
         - lang-python:3.10
+    - name: python-3.11
+      ref:
+      - base
+      chunks:
+        - lang-python:3.11
     - name: ruby-2
       ref:
       - base


### PR DESCRIPTION
## Description
Create image for python 3.11

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/993

## How to test
- Open workspace
- ./build-combo.sh python-3.11
- docker run --rm -it localhost:5000/dazzle:python-3.11 sh
- python --version

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Create image for python 3.11
```