### PR TITLE
Add ruby-3.2 image and update ruby-3 from 3.1.2 to 3.2.0

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -24,6 +24,7 @@
     workspace-ruby-3: "20.*"
     workspace-ruby-3.0: "20.*"
     workspace-ruby-3.1: "20.*"
+    workspace-ruby-3.2: "20.*"
     workspace-rust: "20.*"
     workspace-dotnet: "20.*"
     workspace-postgres: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -21,6 +21,7 @@ sync:
     - ruby-3
     - ruby-3.0
     - ruby-3.1
+    - ruby-3.2
     - rust
     - dotnet
     - postgres

--- a/chunks/lang-ruby/chunk.yaml
+++ b/chunks/lang-ruby/chunk.yaml
@@ -8,3 +8,6 @@ variants:
   - name: "3.1"
     args:
       RUBY_VERSION: 3.1.2
+  - name: "3.2"
+    args:
+      RUBY_VERSION: 3.2.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -103,16 +103,21 @@ combiner:
       - base
       chunks:
         - lang-ruby:3.0
-    - name: ruby-3
-      ref:
-      - base
-      chunks:
-        - lang-ruby:3.1
     - name: ruby-3.1
       ref:
       - base
       chunks:
         - lang-ruby:3.1
+    - name: ruby-3.2
+      ref:
+      - base
+      chunks:
+        - lang-ruby:3.2
+    - name: ruby-3
+      ref:
+      - base
+      chunks:
+        - lang-ruby:3.2
     - name: rust
       ref:
       - base

--- a/tests/lang-ruby.yaml
+++ b/tests/lang-ruby.yaml
@@ -6,7 +6,8 @@
   - stdout.indexOf("ruby") != -1
   - stdout.indexOf("2.7.6") != -1 ||
     stdout.indexOf("3.0.4") != -1 ||
-    stdout.indexOf("3.1.2") != -1
+    stdout.indexOf("3.1.2") != -1 ||
+    stdout.indexOf("3.2.0") != -1
 - desc: it should have rvm
   command: [rvm --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
## Description
- Add ruby-3.2 image (expected to be released at `https://hub.docker.com/r/gitpod/workspace-ruby-3.2`)
- Update [ruby-3](https://hub.docker.com/r/gitpod/workspace-ruby-3) from 3.1.2 to 3.2.0

## Related Issue(s)

Fixes #1004

## How to test

n/a

## Release Notes

```release-note
add ruby-3.2 image
update ruby-3 image from 3.1.2 to 3.2.0
```

## Documentation

* No
  * Are you sure? If so, nothing to do here.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
