### PR TITLE
chore: pin pyenv version

### DIFF
--- a/chunks/lang-python/Dockerfile
+++ b/chunks/lang-python/Dockerfile
@@ -17,8 +17,8 @@ RUN sudo install-packages \
 	libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
 	libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
 	# Install PYENV
-	&& curl -fsSL https://pyenv.run | bash \
-	&& pyenv update \
+	&& git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+	&& git -C ~/.pyenv checkout ff93c58babd813066bf2d64d004a5cee33c0f27b \
 	&& pyenv install ${PYTHON_VERSION} \
 	&& pyenv global ${PYTHON_VERSION} \
 	&& for exec in global; do printf '%s\n' 'source "$HOME/.gp_pyenv.d/userbase.bash"' >> "$PYENV_ROOT/libexec/pyenv-$exec"; done \

--- a/chunks/lang-python/python_hook.bash
+++ b/chunks/lang-python/python_hook.bash
@@ -106,5 +106,4 @@ unset -f pyenv_gitpod_init vscode::add_settings
 # Do not init when sourced internally from `pyenv`
 if test ! -v PYENV_DIR; then {
 	eval "$(pyenv init -)"
-	eval "$(pyenv virtualenv-init -)"
 }; fi

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -42,23 +42,23 @@
     - stdout.indexOf("/workspace/.pyenv_mirror") != -1
 
 # https://github.com/gitpod-io/workspace-images/issues/1000
-# - desc: "`pyenv install <ver>` should use $HOME/.pyenv/versions/ for imagebuild env"
-#   entrypoint: [bash, -c]
-#   command:
-#     [
-#       ver=3.9.0; pyenv install $ver && test -e $PYENV_ROOT/versions/$ver,
-#     ]
-#   assert:
-#     - status == 0
+- desc: "`pyenv install <ver>` should use $HOME/.pyenv/versions/ for imagebuild env"
+  entrypoint: [bash, -c]
+  command:
+    [
+      ver=3.9.0; pyenv install $ver && test -e $PYENV_ROOT/versions/$ver,
+    ]
+  assert:
+    - status == 0
 
-# - desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
-#   entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
-#   command:
-#     [
-#       ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod,
-#     ]
-#   assert:
-#     - status == 0
+- desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
+  entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
+  command:
+    [
+      ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod,
+    ]
+  assert:
+    - status == 0
 
 - desc: "VSCode Python settings are correctly applied"
   entrypoint: [env, GITPOD_REPO_ROOT=/workspace/test, bash, -lic]

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -42,20 +42,12 @@
     - stdout.indexOf("/workspace/.pyenv_mirror") != -1
 
 # https://github.com/gitpod-io/workspace-images/issues/1000
-- desc: "`pyenv install <ver>` should use $HOME/.pyenv/versions/ for imagebuild env"
+- desc: "`pyenv install <ver>` should use $HOME/.pyenv/versions/ for imagebuild env and /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
   entrypoint: [bash, -c]
   command:
     [
-      ver=3.9.0; pyenv install $ver && test -e $PYENV_ROOT/versions/$ver,
-    ]
-  assert:
-    - status == 0
-
-- desc: "`pyenv install <ver>` should use /workspace/.pyenv_mirror/fakeroot/versions/ for workspace-session env and multi-version shims should work"
-  entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
-  command:
-    [
-      ver=3.9.0; pyenv install $ver && test -d $GP_PYENV_FAKEROOT/versions/$ver && test -L $PYENV_ROOT/versions/$ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod,
+      ver=2.1.3; origdir="$PYENV_ROOT/versions/$ver" newVdir="/workspace/.pyenv_mirror/fakeroot/versions";
+      pyenv install $ver && test -e "$origdir" && mkdir -p "$newVdir" && mv "$origdir" "$newVdir" && GITPOD_REPO_ROOT=/workspace bash -ci "pyenv install -s $ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod",
     ]
   assert:
     - status == 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Our custom `pyenv install` hook wasn't working anymore for this new feature of `pyenv install` command:
- https://github.com/pyenv/pyenv/pull/2568

We can patch our hook later to adapt to this change but an quick and reliable solution is to pin `pyenv` to a specific commit, which is recent enough.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/workspace-images/issues/1000

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
