### PR TITLE
feat: bump rust to 1.67

### DIFF
--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -4,7 +4,7 @@ FROM ${base}
 USER gitpod
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=4
+ENV TRIGGER_REBUILD=5
 
 ENV PATH=$HOME/.cargo/bin:$PATH
 


### PR DESCRIPTION
## Description
This triggers a rebuild in the Rust Docker image so that rustup can update rust to 1.67, which was released on January 26, 2023.

## Related Issue(s)
Fixes #1012

## How to test

Create a Rust gitpod workspace and run `rustup --version` ¯\\_(ツ)_/¯

## Release Notes

```release-note
update Rust to 1.67
```

## Documentation

https://github.com/gitpod-io/website/issues/3322