### PR TITLE
Update buildkit and dazzle dependencies

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.6/buildkit-v0.10.6.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🔆 Install skopeo
         run: |
@@ -56,7 +56,7 @@ jobs:
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.6/buildkit-v0.10.6.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,14 +2,14 @@ FROM gitpod/workspace-full
 
 ENV RETRIGGER=3
 
-ENV BUILDKIT_VERSION=0.10.6
+ENV BUILDKIT_VERSION=0.11.2
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 USER root
 
 # Install dazzle, buildkit and pre-commit
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr
-RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
+RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
 RUN curl -sSL https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64 -o /usr/bin/shfmt \
     && chmod +x /usr/bin/shfmt
 RUN install-packages shellcheck \


### PR DESCRIPTION
## Description

* `buildkit` 0.10.6 -> 0.11.2
* `dazzle` v0.1.13 -> v0.1.14

## How to test

Checks must pass.

Alternatively, open a workspace from this branch do the following via our [contribution guide](https://github.com/gitpod-io/workspace-images/blob/829706d31e08dcd202a4b95b5acdb5557964e3bb/CONTRIBUTING.md):
- [x] build a chunk
- [ ] build a combo