### PR TITLE
Change base image to Ubuntu Jammy

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -20,7 +20,6 @@
     workspace-python-3.9: "20.*"
     workspace-python-3.10: "20.*"
     workspace-python-3.11: "20.*"
-    workspace-ruby-2: "20.*"
     workspace-ruby-3: "20.*"
     workspace-ruby-3.0: "20.*"
     workspace-ruby-3.1: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -17,7 +17,6 @@ sync:
     - python-3.9
     - python-3.10
     - python-3.11
-    - ruby-2
     - ruby-3
     - ruby-3.0
     - ruby-3.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DAZZLE_VERSION: 0.1.15
+      BUILDKIT_VERSION: 0.11.2
     steps:
       - name: 📥 Checkout workspace-images
         uses: actions/checkout@v3
@@ -24,11 +27,11 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v${{env.DAZZLE_VERSION}}/dazzle_${{env.DAZZLE_VERSION}}_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v${{env.BUILDKIT_VERSION}}/buildkit-v${{env.BUILDKIT_VERSION}}.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.6/buildkit-v0.10.6.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -23,6 +23,8 @@ jobs:
       GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
       DH_IMAGE_REGISTRY: registry.hub.docker.com
       IAM_SERVICE_ACCOUNT: workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com
+      DAZZLE_VERSION: 0.1.15
+      BUILDKIT_VERSION: 0.11.2
 
     steps:
       - name: 📥 Checkout workspace-images
@@ -43,7 +45,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v${{env.DAZZLE_VERSION}}/dazzle_${{env.DAZZLE_VERSION}}_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🔆 Install skopeo
         run: |
@@ -56,7 +58,7 @@ jobs:
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v${{env.BUILDKIT_VERSION}}/buildkit-v${{env.BUILDKIT_VERSION}}.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 🔆 Install dazzle
         run: |
-          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
+          curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | sudo tar -xvz -C /usr/local/bin
 
       - name: 🔆 Install skopeo
         run: |
@@ -56,7 +56,7 @@ jobs:
 
       - name: 🏗️ Setup buildkit
         run: |
-          curl -sSL https://github.com/moby/buildkit/releases/download/v0.10.6/buildkit-v0.10.6.linux-amd64.tar.gz | sudo tar xvz -C /usr
+          curl -sSL https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-amd64.tar.gz | sudo tar xvz -C /usr
           sudo buildkitd --oci-worker=true --oci-worker-net=host --debug --group docker &
           sudo su -c "while ! test -S /run/buildkit/buildkitd.sock; do sleep 0.1; done"
           sudo chmod +777 /run/buildkit/buildkitd.sock

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -4,12 +4,13 @@ ENV RETRIGGER=3
 
 ENV BUILDKIT_VERSION=0.11.2
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
+ENV DAZZLE_VERSION=0.1.15
 
 USER root
 
 # Install dazzle, buildkit and pre-commit
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr
-RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
+RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v${DAZZLE_VERSION}/dazzle_${DAZZLE_VERSION}_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
 RUN curl -sSL https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64 -o /usr/bin/shfmt \
     && chmod +x /usr/bin/shfmt
 RUN install-packages shellcheck \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,14 +2,14 @@ FROM gitpod/workspace-full
 
 ENV RETRIGGER=3
 
-ENV BUILDKIT_VERSION=0.10.6
+ENV BUILDKIT_VERSION=0.11.2
 ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 USER root
 
 # Install dazzle, buildkit and pre-commit
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr
-RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
+RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.14/dazzle_0.1.14_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
 RUN curl -sSL https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64 -o /usr/bin/shfmt \
     && chmod +x /usr/bin/shfmt
 RUN install-packages shellcheck \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ e.g.
     # fetch keyring over https connection and unpack it using gpg's --dearmor option
     curl -fsSL https://apt.my-secure.org/my-unofficial-repo.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/my-unofficial-repo.gpg.key
     # and then add them to a apt key sources list.
-    echo "deb [signed-by=/usr/share/keyrings/my-unofficial-repo.gpg.key] http://apt.my-secure.org/focal/ \
+    echo "deb [signed-by=/usr/share/keyrings/my-unofficial-repo.gpg.key] http://apt.my-secure.org/jammy/ \
     my-unofficial-repo-toolchain main" | sudo tee /etc/apt/sources.list.d/my-unofficial-repo.list > /dev/null
     ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Each contains a set of chunks: a common base, and a language, and includes Docke
 - [`gitpod/workspace-node`](https://hub.docker.com/r/gitpod/workspace-node) ✅
 - [`gitpod/workspace-node-lts`](https://hub.docker.com/r/gitpod/workspace-node-lts) ✅
 - [`gitpod/workspace-python`](https://hub.docker.com/r/gitpod/workspace-python) ✅
-- [`gitpod/workspace-ruby-2`](https://hub.docker.com/r/gitpod/workspace-ruby-2) ✅
 - [`gitpod/workspace-ruby-3`](https://hub.docker.com/r/gitpod/workspace-ruby-3) ✅
 - [`gitpod/workspace-ruby-3.0`](https://hub.docker.com/r/gitpod/workspace-ruby-3.0) ✅
 - [`gitpod/workspace-ruby-3.1`](https://hub.docker.com/r/gitpod/workspace-ruby-3.1) ✅
@@ -87,6 +86,7 @@ These images are no longer being published:
 
 - gitpod/workspace-python-3.6 (please use [`gitpod/workspace-python-3.7`](https://hub.docker.com/r/gitpod/workspace-python-3.7) instead)
 - gitpod/workspace-postgresql (please use [`gitpod/workspace-postgres`](https://hub.docker.com/r/gitpod/workspace-postgres) instead)
+- gitpod/workspace-ruby-2 (please use [`gitpod/workspace-ruby-3.2`](https://hub.docker.com/r/gitpod/workspace-ruby-3.2) instead)
 
 ## Contributing
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal
+FROM buildpack-deps:jammy
 
 COPY install-packages upgrade-packages /usr/bin/
 

--- a/base/install-packages
+++ b/base/install-packages
@@ -26,7 +26,7 @@ if [[ $EUID != 0 ]]; then
 fi
 
 # Set a runlevel to avoid invoke-rc.d warnings
-# http://manpages.ubuntu.com/manpages/focal/man8/runlevel.8.html#environment
+# http://manpages.ubuntu.com/manpages/jammy/man8/runlevel.8.html#environment
 # shellcheck disable=SC2034
 RUNLEVEL=1
 

--- a/chunks/lang-c/Dockerfile
+++ b/chunks/lang-c/Dockerfile
@@ -7,8 +7,8 @@ USER root
 ENV TRIGGER_REBUILD=1
 
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/focal/ \
-    llvm-toolchain-focal-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ \
+    llvm-toolchain-jammy-15 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
     && apt update \
     && install-packages \
         clang \

--- a/chunks/lang-elixir/Dockerfile
+++ b/chunks/lang-elixir/Dockerfile
@@ -6,9 +6,23 @@ USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=1
 
-RUN cd /tmp \
-	&& wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
-	&& dpkg -i erlang-solutions_2.0_all.deb \
-	&& install-packages elixir
-
 USER gitpod
+
+# Install asdf to make it easier to manage elixir versions
+#
+# Why?
+# 1. At the time of this writing, `apt-get install elixir` was installing
+# a version that was not compatible with glibc in Ubuntu Jammy.
+# 2. This makes it explicit as to what versions we're installing.
+# 3. It'll give users the ability to easily make changes at runtime to experiment
+RUN	git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1
+RUN echo ". "$HOME/.asdf/asdf.sh"" >> /home/gitpod/.bashrc.d/100-asdf
+RUN echo ". "$HOME/.asdf/completions/asdf.bash"" >> /home/gitpod/.bashrc.d/100-asdf
+ENV PATH=/home/gitpod/.asdf/bin:/home/gitpod/.asdf/shims:$PATH
+
+RUN asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
+RUN asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
+RUN asdf install erlang 25.2.2
+RUN asdf install elixir 1.13.4-otp-25
+RUN asdf global erlang 25.2.2
+RUN asdf global elixir 1.13.4-otp-25

--- a/chunks/lang-go/Dockerfile
+++ b/chunks/lang-go/Dockerfile
@@ -11,19 +11,20 @@ ENV GO_VERSION=${GO_VERSION}
 ENV GOPATH=$HOME/go-packages
 ENV GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-RUN curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xzs && \
+RUN curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz | tar xzs
 # install VS Code Go tools for use with gopls as per https://github.com/golang/vscode-go/blob/master/docs/tools.md
 # also https://github.com/golang/vscode-go/blob/27bbf42a1523cadb19fad21e0f9d7c316b625684/src/goTools.ts#L139
-    go install -v github.com/uudashr/gopkgs/cmd/gopkgs@v2 && \
-    go install -v github.com/ramya-rao-a/go-outline@latest && \
-    go install -v github.com/cweill/gotests/gotests@latest && \
-    go install -v github.com/fatih/gomodifytags@latest && \
-    go install -v github.com/josharian/impl@latest && \
-    go install -v github.com/haya14busa/goplay/cmd/goplay@latest && \
-    go install -v github.com/go-delve/delve/cmd/dlv@latest && \
-    go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
-    go install -v golang.org/x/tools/gopls@latest && \
-    go install -v honnef.co/go/tools/cmd/staticcheck@latest && \
-    sudo rm -rf $GOPATH/src $GOPATH/pkg $HOME/.cache/go $HOME/.cache/go-build && \
+RUN go install -v github.com/uudashr/gopkgs/cmd/gopkgs@v2 \
+&& go install -v github.com/ramya-rao-a/go-outline@latest \
+&& go install -v github.com/cweill/gotests/gotests@latest \
+&& go install -v github.com/fatih/gomodifytags@latest \
+&& go install -v github.com/josharian/impl@latest \
+&& go install -v github.com/haya14busa/goplay/cmd/goplay@latest \
+&& go install -v github.com/go-delve/delve/cmd/dlv@latest \
+&& go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
+&& go install -v golang.org/x/tools/gopls@latest \
+&& go install -v honnef.co/go/tools/cmd/staticcheck@latest
+
+RUN sudo rm -rf $GOPATH/src $GOPATH/pkg $HOME/.cache/go $HOME/.cache/go-build && \
     printf '%s\n' 'export GOPATH=/workspace/go' \
-                  'export PATH=$GOPATH/bin:$PATH' > $HOME/.bashrc.d/300-go
+    'export PATH=$GOPATH/bin:$PATH' > $HOME/.bashrc.d/300-go

--- a/chunks/lang-go/chunk.yaml
+++ b/chunks/lang-go/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
-  - name: "1.18.10"
-    args:
-      GO_VERSION: 1.18.10
   - name: "1.19.5"
     args:
       GO_VERSION: 1.19.5
+  - name: "1.20"
+    args:
+      GO_VERSION: 1.20

--- a/chunks/lang-node/Dockerfile
+++ b/chunks/lang-node/Dockerfile
@@ -12,7 +12,7 @@ ENV NODE_VERSION=${NODE_VERSION}
 ENV PNPM_HOME=/home/gitpod/.pnpm
 ENV PATH=/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin:/home/gitpod/.yarn/bin:${PNPM_HOME}:$PATH
 
-RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | PROFILE=/dev/null bash \
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | PROFILE=/dev/null bash \
     && bash -c ". .nvm/nvm.sh \
         && nvm install v${NODE_VERSION} \
         && nvm alias default v${NODE_VERSION} \

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
-  - name: "16"
-    args:
-      NODE_VERSION: 16.19.1
   - name: "18"
     args:
       NODE_VERSION: 18.14.2
+  - name: "19"
+    args:
+      NODE_VERSION: 19.7.0

--- a/chunks/lang-ruby/Dockerfile
+++ b/chunks/lang-ruby/Dockerfile
@@ -12,20 +12,21 @@ RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import -
 RUN curl -fsSL https://rvm.io/pkuczynski.asc | gpg --import -
 RUN curl -fsSL https://get.rvm.io | bash -s stable
 
-# ENV GEM_HOME=/home/gitpod/.rvm
-# ENV GEM_PATH=$GEM_HOME:$GEM_PATH
+ENV GEM_HOME=/workspace/.rvm
+ENV GEM_PATH=$GEM_HOME:$GEM_PATH
 ENV PATH=/home/gitpod/.rvm/bin:$PATH
 
-RUN rvm requirements
-
-# TODO: remove me once fixed, https://github.com/rvm/rvm/issues/5209#issuecomment-1114159447
+# the version of openssl changed in Jammy, some versions of Ruby need an older version
+# https://github.com/rvm/rvm/issues/5209#issuecomment-1114159447
 # another option: https://github.com/rvm/rvm/issues/5209#issuecomment-1134927685 or sudo apt install libssl-dev=1.1.1l-1ubuntu1.4
-RUN rvm pkg install openssl
+RUN bash -lc " \
+        rvm requirements \
+        && rvm pkg install openssl \
+        && rvm install ${RUBY_VERSION} --with-openssl-dir=$HOME/.rvm/usr --default \
+        && rvm alias create default $RUBY_VERSION \
+        && rvm rubygems current \
+        && gem install bundler --no-document \
+        && gem install solargraph --no-document"
 
-# RUN rvm install $RUBY_VERSION --with-openssl-dir=$HOME/.rvm/user
-# RUN rvm use $RUBY_VERSION --default
-# RUN rvm rubygems current
-# RUN gem install bundler --no-document
-# RUN gem install solargraph --no-document
-# RUN echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*' >> /home/gitpod/.bashrc.d/70-ruby
-# RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
+RUN echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*' >> /home/gitpod/.bashrc.d/70-ruby
+RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc

--- a/chunks/lang-ruby/Dockerfile
+++ b/chunks/lang-ruby/Dockerfile
@@ -8,19 +8,24 @@ USER gitpod
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=1
 
-RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import - \
-    && curl -fsSL https://rvm.io/pkuczynski.asc | gpg --import - \
-    && curl -fsSL https://get.rvm.io | bash -s stable \
-    && bash -lc " \
-        rvm requirements \
-        && rvm install ${RUBY_VERSION} \
-        && rvm use ${RUBY_VERSION} --default \
-        && rvm rubygems current \
-        && gem install bundler --no-document \
-        && gem install solargraph --no-document" \
-    && echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*' >> /home/gitpod/.bashrc.d/70-ruby
-RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
+RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import -
+RUN curl -fsSL https://rvm.io/pkuczynski.asc | gpg --import -
+RUN curl -fsSL https://get.rvm.io | bash -s stable
 
-ENV GEM_HOME=/workspace/.rvm
-ENV GEM_PATH=$GEM_HOME:$GEM_PATH
-ENV PATH=/workspace/.rvm/bin:$PATH
+# ENV GEM_HOME=/home/gitpod/.rvm
+# ENV GEM_PATH=$GEM_HOME:$GEM_PATH
+ENV PATH=/home/gitpod/.rvm/bin:$PATH
+
+RUN rvm requirements
+
+# TODO: remove me once fixed, https://github.com/rvm/rvm/issues/5209#issuecomment-1114159447
+# another option: https://github.com/rvm/rvm/issues/5209#issuecomment-1134927685 or sudo apt install libssl-dev=1.1.1l-1ubuntu1.4
+RUN rvm pkg install openssl
+
+# RUN rvm install $RUBY_VERSION --with-openssl-dir=$HOME/.rvm/user
+# RUN rvm use $RUBY_VERSION --default
+# RUN rvm rubygems current
+# RUN gem install bundler --no-document
+# RUN gem install solargraph --no-document
+# RUN echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*' >> /home/gitpod/.bashrc.d/70-ruby
+# RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc

--- a/chunks/lang-ruby/Dockerfile
+++ b/chunks/lang-ruby/Dockerfile
@@ -6,27 +6,21 @@ ARG RUBY_VERSION
 USER gitpod
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 
 RUN curl -fsSL https://rvm.io/mpapis.asc | gpg --import -
 RUN curl -fsSL https://rvm.io/pkuczynski.asc | gpg --import -
 RUN curl -fsSL https://get.rvm.io | bash -s stable
 
-ENV GEM_HOME=/workspace/.rvm
-ENV GEM_PATH=$GEM_HOME:$GEM_PATH
-ENV PATH=/home/gitpod/.rvm/bin:$PATH
+ADD ./install.sh /tmp
+RUN /tmp/install.sh $RUBY_VERSION
 
-# the version of openssl changed in Jammy, some versions of Ruby need an older version
-# https://github.com/rvm/rvm/issues/5209#issuecomment-1114159447
-# another option: https://github.com/rvm/rvm/issues/5209#issuecomment-1134927685 or sudo apt install libssl-dev=1.1.1l-1ubuntu1.4
-RUN bash -lc " \
-        rvm requirements \
-        && rvm pkg install openssl \
-        && rvm install ${RUBY_VERSION} --with-openssl-dir=$HOME/.rvm/usr --default \
-        && rvm alias create default $RUBY_VERSION \
-        && rvm rubygems current \
-        && gem install bundler --no-document \
-        && gem install solargraph --no-document"
+
+
 
 RUN echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*' >> /home/gitpod/.bashrc.d/70-ruby
 RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
+
+ENV GEM_HOME=/workspace/.rvm
+ENV GEM_PATH=$GEM_HOME:$GEM_PATH
+ENV PATH=/home/gitpod/.rvm/bin:$PATH

--- a/chunks/lang-ruby/chunk.yaml
+++ b/chunks/lang-ruby/chunk.yaml
@@ -1,10 +1,7 @@
 variants:
-  - name: "2.7"
-    args:
-      RUBY_VERSION: 2.7.7
   - name: "3.0"
     args:
-      RUBY_VERSION: 3.0.4
+      RUBY_VERSION: 3.0.5
   - name: "3.1"
     args:
       RUBY_VERSION: 3.1.3

--- a/chunks/lang-ruby/chunk.yaml
+++ b/chunks/lang-ruby/chunk.yaml
@@ -1,13 +1,13 @@
 variants:
   - name: "2.7"
     args:
-      RUBY_VERSION: 2.7.6
+      RUBY_VERSION: 2.7.7
   - name: "3.0"
     args:
       RUBY_VERSION: 3.0.4
   - name: "3.1"
     args:
-      RUBY_VERSION: 3.1.2
+      RUBY_VERSION: 3.1.3
   - name: "3.2"
     args:
-      RUBY_VERSION: 3.2.0
+      RUBY_VERSION: 3.2.1

--- a/chunks/lang-ruby/install.sh
+++ b/chunks/lang-ruby/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+RUBY_VERSION=$1
+
+# the version of openssl changed in Jammy, Ruby 3.0 needs an older version
+# https://github.com/rvm/rvm/issues/5209#issuecomment-1114159447
+# another option: https://github.com/rvm/rvm/issues/5209#issuecomment-1134927685 or sudo apt install libssl-dev=1.1.1l-1ubuntu1.4
+if grep -q "3.0." <<<"${RUBY_VERSION}"; then
+	bash -lc "
+        rvm requirements \
+        && rvm pkg install openssl \
+        && rvm install \"${RUBY_VERSION}\" --with-openssl-dir=\"${HOME}\"/.rvm/usr --default \
+        && rvm alias create default \"${RUBY_VERSION}\" \
+        && rvm rubygems current \
+        && gem install bundler --no-document \
+        && gem install solargraph --no-document"
+else
+	# Ruby 3.1 and higher do not
+	bash -lc "
+        rvm requirements \
+        && rvm install \"${RUBY_VERSION}\" --default \
+        && rvm alias create default \"${RUBY_VERSION}\" \
+        && rvm rubygems current \
+        && gem install bundler --no-document \
+        && gem install solargraph --no-document"
+fi

--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -4,7 +4,7 @@ FROM ${base}
 USER gitpod
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=4
+ENV TRIGGER_REBUILD=5
 
 ENV PATH=$HOME/.cargo/bin:$PATH
 

--- a/chunks/tool-brew/Dockerfile
+++ b/chunks/tool-brew/Dockerfile
@@ -12,5 +12,4 @@ ENV MANPATH="$MANPATH:/home/linuxbrew/.linuxbrew/share/man"
 ENV INFOPATH="$INFOPATH:/home/linuxbrew/.linuxbrew/share/info"
 ENV HOMEBREW_NO_AUTO_UPDATE=1
 
-RUN sudo apt remove -y cmake \
-    && brew install cmake
+RUN brew install cmake

--- a/chunks/tool-mongodb/Dockerfile
+++ b/chunks/tool-mongodb/Dockerfile
@@ -6,11 +6,20 @@ USER gitpod
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=1
 
+# Install MongoDB Shell aka MongoSH (was part of Mongo 5, but, is separate now)
+RUN mkdir -p /tmp/mongosh && \
+    cd /tmp/mongosh && \
+    wget -qOmongosh.tgz https://downloads.mongodb.com/compass/mongosh-1.8.0-linux-x64.tgz && \
+    tar xf mongosh.tgz && \
+    cd mongosh-* && \
+    sudo cp bin/* /usr/local/bin/ && \
+    rm -rf /tmp/mongosh
+
 # Install MongoDB
 # Source: https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu-tarball/#install-mongodb-community-edition
 RUN mkdir -p /tmp/mongodb && \
     cd /tmp/mongodb && \
-    wget -qOmongodb.tgz https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.2.tgz && \
+    wget -qOmongodb.tgz https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.4.tgz && \
     tar xf mongodb.tgz && \
     cd mongodb-* && \
     sudo cp bin/* /usr/local/bin/ && \

--- a/chunks/tool-postgresql/Dockerfile
+++ b/chunks/tool-postgresql/Dockerfile
@@ -7,7 +7,9 @@ ENV PGWORKSPACE="/workspace/.pgsql"
 ENV PGDATA="$PGWORKSPACE/data"
 
 # Install PostgreSQL
-RUN sudo install-packages postgresql-12 postgresql-contrib-12
+RUN sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - && \
+    sudo install-packages postgresql-12 postgresql-contrib-12
 
 # Setup PostgreSQL server for user gitpod
 ENV PATH="/usr/lib/postgresql/12/bin:$PATH"

--- a/chunks/tool-tailscale/Dockerfile
+++ b/chunks/tool-tailscale/Dockerfile
@@ -6,8 +6,8 @@ USER root
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
 ENV TRIGGER_REBUILD=3
 
-RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key add - \
-    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
+RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.gpg | sudo apt-key add - \
+    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.list | sudo tee /etc/apt/sources.list.d/tailscale.list \
     && apt-get update \
     && apt-get install -y tailscale \
     && rm /etc/apt/sources.list.d/tailscale.list \

--- a/chunks/tool-yugabytedb/Dockerfile
+++ b/chunks/tool-yugabytedb/Dockerfile
@@ -7,6 +7,7 @@ ARG YB_VERSION
 ARG YB_BUILD
 ARG YB_BIN_PATH=/usr/local/yugabyte
 ARG ROLE=gitpod
+ARG PYTHON_VERSION
 
 USER $ROLE
 # create bin and data path
@@ -21,6 +22,17 @@ RUN curl -sSLo ./yugabyte.tar.gz https://downloads.yugabyte.com/releases/${YB_VE
   && tar -xvf yugabyte.tar.gz -C $YB_BIN_PATH --strip-components=1 \
   && chmod +x $YB_BIN_PATH/bin/* \
   && rm ./yugabyte.tar.gz
+
+# python is a required dependency of ycqlsh
+# but it doesn't support Python 3.10+ due to https://github.com/yugabyte/cqlsh/issues/11, install 3.9 for now
+# when building yugabyte combos, if our base is full, related python chunk tests fail
+# so, use base as the combo ref, add chunks, but ignore Python chunk and install manually
+ENV PATH="$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH"
+ENV PYENV_ROOT="$HOME/.pyenv"
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+	&& git -C ~/.pyenv checkout ff93c58babd813066bf2d64d004a5cee33c0f27b \
+	&& pyenv install ${PYTHON_VERSION} \
+	&& pyenv global ${PYTHON_VERSION}
 
 # configure the interpreter
 RUN ["/usr/local/yugabyte/bin/post_install.sh"]

--- a/chunks/tool-yugabytedb/chunk.yaml
+++ b/chunks/tool-yugabytedb/chunk.yaml
@@ -3,7 +3,9 @@ variants:
     args:
       YB_VERSION: 2.14.0.0
       YB_BUILD: 94
+      PYTHON_VERSION: 3.9
   - name: "2.15"
     args:
       YB_VERSION: 2.15.0.1
       YB_BUILD: 4
+      PYTHON_VERSION: 3.9

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -28,7 +28,7 @@ combiner:
         - lang-clojure
         - lang-go:1.19.5
         - lang-java:11
-        - lang-node:16
+        - lang-node:18
         - lang-python:3.8
         - lang-ruby:3.1
         - lang-rust
@@ -55,13 +55,13 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:18
+        - lang-node:19
         - tool-chrome
     - name: node-lts
       ref:
       - base
       chunks:
-        - lang-node:16
+        - lang-node:18
         - tool-chrome
     - name: python
       ref:

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -29,8 +29,8 @@ combiner:
         - lang-go:1.19.5
         - lang-java:11
         - lang-node:18
-        - lang-python:3.8
-        - lang-ruby:3.1
+        - lang-python:3.11
+        - lang-ruby:3.2
         - lang-rust
         - tool-brew
         - tool-nginx

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -150,13 +150,33 @@ combiner:
         - lang-java:17
     - name: yugabytedb
       ref:
-      - full
+      - base
       chunks:
+        - lang-c
+        - lang-clojure
+        - lang-go:1.19.5
+        - lang-java:11
+        - lang-node:18
+        - lang-ruby:3.2
+        - lang-rust
+        - tool-brew
+        - tool-nginx
+        - tool-nix:2.11.0
         - tool-yugabytedb:2.14
     - name: yugabytedb-preview
       ref:
-      - full
+      - base
       chunks:
+        - lang-c
+        - lang-clojure
+        - lang-go:1.19.5
+        - lang-java:11
+        - lang-node:18
+        - lang-ruby:3.2
+        - lang-rust
+        - tool-brew
+        - tool-nginx
+        - tool-nix:2.11.0
         - tool-yugabytedb:2.15
   envvars:
     - name: PATH

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -93,11 +93,6 @@ combiner:
       - base
       chunks:
         - lang-python:3.11
-    - name: ruby-2
-      ref:
-      - base
-      chunks:
-        - lang-ruby:2.7
     - name: ruby-3.0
       ref:
       - base

--- a/tests/lang-elixir.yaml
+++ b/tests/lang-elixir.yaml
@@ -2,5 +2,5 @@
   command: [elixir,--version]
   assert:
   - status == 0
-  - stdout.indexOf("Erlang/OTP 2") != -1
-  - stdout.indexOf("Elixir 1.13.") != -1
+  - stdout.indexOf("Erlang/OTP 25") != -1
+  - stdout.indexOf("Elixir 1.13.4") != -1

--- a/tests/lang-java.yaml
+++ b/tests/lang-java.yaml
@@ -6,12 +6,12 @@
   - stderr.indexOf("OpenJDK")   != -1
   - stderr.indexOf("11.0.")   != -1 ||
     stderr.indexOf("17.0.")    != -1
-- desc: it should have a functioning java 17.0.5 installed
+- desc: it should have a functioning java 17.0.6 installed
   entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
-  command: [sdk default java 17.0.5.fx-zulu && java -version && mvn -v]
+  command: [sdk default java 17.0.6.fx-zulu && java -version && mvn -v]
   assert:
   - status == 0
-  - stderr.indexOf('openjdk version "17.0.5"') != -1
+  - stderr.indexOf('openjdk version "17.0.6"') != -1
   - stdout.indexOf("Apache Maven") != -1
 - desc: it should run maven
   command: [mvn -v]

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -3,8 +3,8 @@
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("v16") != -1 ||
-    stdout.indexOf("v18")  != -1
+  - stdout.indexOf("v18")  != -1 ||
+    stdout.indexOf("v19")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]

--- a/tests/lang-ruby.yaml
+++ b/tests/lang-ruby.yaml
@@ -1,13 +1,12 @@
-- desc: it should run ruby
+- desc: it should have ruby
   command: [ruby --version]
   entrypoint: [bash, -i, -c]
   assert:
-  - status == 0
   - stdout.indexOf("ruby") != -1
-  - stdout.indexOf("2.7.7") != -1 ||
-    stdout.indexOf("3.0.4") != -1 ||
+  - stdout.indexOf("3.0.5") != -1 ||
     stdout.indexOf("3.1.3") != -1 ||
     stdout.indexOf("3.2.1") != -1
+  - status == 0
 - desc: it should have rvm
   command: [rvm --version]
   entrypoint: [bash, -i, -c]

--- a/tests/lang-ruby.yaml
+++ b/tests/lang-ruby.yaml
@@ -4,10 +4,10 @@
   assert:
   - status == 0
   - stdout.indexOf("ruby") != -1
-  - stdout.indexOf("2.7.6") != -1 ||
+  - stdout.indexOf("2.7.7") != -1 ||
     stdout.indexOf("3.0.4") != -1 ||
-    stdout.indexOf("3.1.2") != -1 ||
-    stdout.indexOf("3.2.0") != -1
+    stdout.indexOf("3.1.3") != -1 ||
+    stdout.indexOf("3.2.1") != -1
 - desc: it should have rvm
   command: [rvm --version]
   entrypoint: [bash, -i, -c]

--- a/tests/tool-brew.yaml
+++ b/tests/tool-brew.yaml
@@ -7,7 +7,13 @@
   command: [brew, doctor]
   assert:
   - stderr.indexOf("error") == -1
+  - status == 0
 - desc: it should have valid configuration
   command: [brew, config]
   assert:
+  - status == 0
+- desc: it should have cmake
+  command: [cmake, --version]
+  assert:
+  - stderr.indexOf("cmake version") == -1
   - status == 0

--- a/tests/tool-mongodb.yaml
+++ b/tests/tool-mongodb.yaml
@@ -1,12 +1,12 @@
-- desc: it should run mongodb shell
-  command: [mongo --version]
+- desc: it should run mongosh
+  command: [mongosh --version]
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("MongoDB shell version v5.0.2") != -1
-- desc: it should run mongodb shell
+  - stdout.indexOf("1.8.0") != -1
+- desc: it should run mongod
   command: [mongod --version]
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-  - stdout.indexOf("db version v5.0.2") != -1
+  - stdout.indexOf("db version v6.0.4") != -1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Breaking changes
1. Update maintained images[[1](https://github.com/gitpod-io/workspace-images/#-images-well-maintain)][[2](https://github.com/gitpod-io/workspace-images/#-specific-images)] at https://hub.docker.com/u/gitpod from Focal to Jammy
2. [Deprecate and do not update `gitpod/workspace-ruby-2`; Ruby 2.7 is EOL March 31, 2023](https://endoflife.date/ruby).
3. Upgrade `gitpod/workspace-mongodb` to mongo v6. v5 doesn't support OpenSSL 3, [OpenSSL 3 comes out of the box with Jammy](https://packages.ubuntu.com/source/jammy/openssl).
4. Update `gitpod/workspace-node-lts` from Node 16 to Node 18, and also in `gitpod/workspace-full`
5. Update `gitpod/workspace-node` from Node 18 to Node 19
6. Install Python 3.9 in `gitpod/workspace-yugabytedb*`, changing its `base` ref from `full`. Refer to its [dockerfile](https://github.com/gitpod-io/workspace-images/blob/kylos101/jam/chunks/tool-yugabytedb/Dockerfile#L27) for background

Fixes
1. Replace Go 1.18 (which was failing the build on `dazzle build` and not part of any dazzle combination / workspace image), with Go 1.20. 
   * Continue using 1.19.5 in the go combination (so there is no change to users) for `gitpod/workspace-full` or `gitpod/workspace-go`.
   * We should switch to 1.20 as part of the next release, @atduarte and @loujaybee for :eyes: 
2. Bump Rust to 1.67.1
3. Bump Ruby patch versions for 3.0, 3.1, and 3.2
4. Override OpenSSL for Ruby 3.0 to support Jammy
5. Bump Ruby in `gitpod/workspace-full` from Ruby 3.1 to 3.2
6. Bump Python in `gitpod/workspace-full` from Python 3.8 to 3.11
7. Bump nvm version from 0.39.0 to 0.39.3
8. Bump buildkit and dazzle dependencies for CI

New features
1. Use asdf version manager in Elixir combination to more easily manage erlang and elixir

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes: #810, #1016, #1029 and #1012

## How to test
<!-- Provide steps to test this PR -->
- Our tests pass in this build.
- After this merges to main
   - Our [base image](https://github.com/gitpod-io/gitpod/blob/main/dev/image/Dockerfile#L5) is updated to use the timestamped image, so we can dog food the change.
   - Early adopters use the timestamped image and share feedback

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
breaking: Upgrade to Ubuntu `22.04` LTS (Jammy Jellyfish)
, please refer to https://www.gitpod.io/changelog/january-changelog#workspace-images-os-and-node-versions-update for details.
```