### PR TITLE
Enable building of images outside of GitPod!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM gitpod/workspace-full
+
+ENV RETRIGGER=3
+
+ENV BUILDKIT_VERSION=0.10.6
+ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
+
+USER root
+
+# Install dazzle, buildkit and pre-commit
+RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr
+RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
+RUN curl -sSL https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64 -o /usr/bin/shfmt \
+    && chmod +x /usr/bin/shfmt
+RUN install-packages shellcheck \
+    && pip3 install pre-commit
+RUN curl -sSL https://github.com/mikefarah/yq/releases/download/v4.22.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+
+ADD . workspace-images/
+WORKDIR workspace-images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM ecarrel/dazzle:upgrade_go_zipexec
 
 ENV RETRIGGER=3
 
@@ -7,13 +7,14 @@ ENV BUILDKIT_FILENAME=buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz
 
 USER root
 
+RUN apk add curl bash
+
 # Install dazzle, buildkit and pre-commit
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/${BUILDKIT_FILENAME} | tar -xvz -C /usr
-RUN curl -sSL https://github.com/gitpod-io/dazzle/releases/download/v0.1.13/dazzle_0.1.13_Linux_x86_64.tar.gz | tar -xvz -C /usr/local/bin
 RUN curl -sSL https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64 -o /usr/bin/shfmt \
     && chmod +x /usr/bin/shfmt
-RUN install-packages shellcheck \
-    && pip3 install pre-commit
+# RUN install-packages shellcheck \
+#     && pip3 install pre-commit
 RUN curl -sSL https://github.com/mikefarah/yq/releases/download/v4.22.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 
 ADD . workspace-images/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services: 
+  buildkitd:
+    image: docker.io/moby/buildkit:latest
+    command: ["--addr", "tcp://0.0.0.0:1234"]
+    networks:
+      -  "dazzle-net"
+    ports: 
+      - "1234:1234"
+      
+  registry:
+    image: registry:2
+    networks:
+      -  "dazzle-net"
+    expose:
+      - "5000"
+    ports: 
+      - "5000:5000"
+      
+  workspace-images:
+    image: workspace-images
+    depends_on:
+      - buildkitd
+      - registry
+    environment:
+      DAZZLE_BUILDKITD_ADDR=tcp://buildkitd:5000
+    networks:
+      - "dazzle-net"
+    profiles:
+      - cmd
+
+
+networks:
+  dazzle-net: {}


### PR DESCRIPTION
## Description

Enable building of images outside of GitPod!

## Related Issue(s)
Fixes #1037 

## How to test
Run: ```
docker build -t gitpod-io/workspace-images:latest .
docker-compose run gitpod-io/workspace-images:latest ./build-all.sh
```
Watch images build into the registry running within docker-compose!

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Workspace image creation no longer depends upon execution within GitPod. Execution outside of GitPod will require `docker` and `docker-compose`, or their `podman` counterparts.
```

## Documentation

Will add documentation update if PR gets closed to landing. This will require a different incantation to get the image builds going.
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
