### PR TITLE
Update Tailscale to 1.36.2

### DIFF
--- a/chunks/tool-tailscale/Dockerfile
+++ b/chunks/tool-tailscale/Dockerfile
@@ -4,7 +4,7 @@ FROM ${base}
 USER root
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=2
+ENV TRIGGER_REBUILD=3
 
 RUN curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | sudo apt-key add - \
     && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | sudo tee /etc/apt/sources.list.d/tailscale.list \


### PR DESCRIPTION
Refreshing tailscale to 1.36.2 ensures we now have `tailscale update` as command, allowing users to auto-update tailscale in their environment automatically in the future.

