### PR TITLE
configure PyCharm default interpreter

### DIFF
--- a/chunks/lang-python/Dockerfile
+++ b/chunks/lang-python/Dockerfile
@@ -11,6 +11,9 @@ ENV PATH="$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH"
 ENV PIPENV_VENV_IN_PROJECT=true
 ENV PYENV_ROOT="$HOME/.pyenv"
 
+# configure the default intepreter for PyCharm
+ENV PYCHARM_PYTHON_PATH="$HOME/.pyenv/shims/python"
+
 RUN sudo install-packages \
 	# Install python compiling dependencies for pyenv
 	python3-pip make build-essential libssl-dev zlib1g-dev \

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -57,3 +57,10 @@
   command: [rm /tmp/.vscs_add.lock; for sj in "$HOME/.vscode-server/data/Machine/settings.json" "/workspace/.vscode-remote/data/Machine/settings.json"; do mkdir -p $(dirname "$sj") "$GITPOD_REPO_ROOT" && touch "$sj" && bash -lic 'true' && if ! grep -q 'python' "$sj"; then exit 1; fi; done]
   assert:
     - status == 0
+
+- desc: "python default interpreter for PyCharm should be configured"
+  entrypoint: [bash, -c]
+  command: [echo $PYCHARM_PYTHON_PATH]
+  assert:
+    - status == 0
+    - stdout.indexOf("/home/gitpod/.pyenv/shims/python") != -1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It ensures that in workspaces started on our images PyCharm can detect default interpreter.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
PyCharm: configure the default interpreter
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
