### PR TITLE
fix python bash hook for ubuntu jammy

### DIFF
--- a/chunks/lang-python/pyenv.d/exec/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/exec/gitpod.bash
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# export PYTHONPATH="${GP_PYENV_MIRROR}/site/${PYENV_VERSION}" # `pip install` will use this path.
+# export PYTHONPATH="${PYENV_MIRROR}/site/${PYENV_VERSION}" # `pip install` will use this path.
 # # Do not set PIP_TARGET when `--user` arg is passed to `pip install` to avoid
 # ## ERROR: Can not combine '--user' and '--target'.
 # if [[ ! "$*" =~ pip[0-9]?\ install.*--user ]]; then {
@@ -18,7 +18,7 @@ if test "$pyenv_version" != "$mounted_version"; then {
 }; fi
 
 # For pyenv-global multiple-version shims
-if [[ "$PYENV_VERSION" =~ : ]] && [[ "$PYENV_COMMAND_PATH" =~ "$GP_PYENV_MIRROR"/user ]] && [[ "$(<"$PYENV_COMMAND_PATH")" =~ \#\!("${GP_PYENV_FAKEROOT}"|"$PYENV_ROOT")/versions/([0-9]+(\.[0-9]+)*)/bin ]]; then {
+if [[ "$PYENV_VERSION" =~ : ]] && [[ "$PYENV_COMMAND_PATH" =~ "$PYENV_MIRROR"/user ]] && [[ "$(<"$PYENV_COMMAND_PATH")" =~ \#\!("${PYENV_FAKEROOT}"|"$PYENV_ROOT")/versions/([0-9]+(\.[0-9]+)*)/bin ]]; then {
 	multi_shim_version="${BASH_REMATCH[2]}"
 	if test "$mounted_version" != "$multi_shim_version"; then {
 		export PYTHONUSERBASE="${PYTHONUSERBASE%/*}/$multi_shim_version"

--- a/chunks/lang-python/pyenv.d/install/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/install/gitpod.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ver="${DEFINITION##*/}"
-if test -e "$PYENV_ROOT/versions/$ver" && test ! -e "$GP_PYENV_FAKEROOT/versions/$ver" &&
+if test -e "$PYENV_ROOT/versions/$ver" && test ! -e "$PYENV_FAKEROOT/versions/$ver" &&
 	[ -z "$FORCE" ] && [ -z "$SKIP_EXISTING" ]; then {
 		echo "pyenv: $ver already exists" >&2
 		read -rp "continue with installation? (y/N) "
@@ -11,11 +11,11 @@ if test -e "$PYENV_ROOT/versions/$ver" && test ! -e "$GP_PYENV_FAKEROOT/versions
 	}; fi
 
 ORIG_PYENV_ROOT="$PYENV_ROOT"
-PYENV_ROOT="$GP_PYENV_FAKEROOT" # Temporarily hijack PYENV_ROOT
+PYENV_ROOT="$PYENV_FAKEROOT" # Temporarily hijack PYENV_ROOT
 
 function after_job() {
 	PYENV_ROOT="$ORIG_PYENV_ROOT"
-	unset GP_PYENV_INIT
+	unset PYENV_INIT
 	# shellcheck disable=SC1090
 	source "$HOME/.bashrc.d/"*-python
 	# pyenv-rehash && PYENV_VERSION="$ver" pip install --upgrade pip

--- a/chunks/lang-python/pyenv.d/install/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/install/gitpod.bash
@@ -15,7 +15,7 @@ PYENV_ROOT="$PYENV_FAKEROOT" # Temporarily hijack PYENV_ROOT
 
 function after_job() {
 	PYENV_ROOT="$ORIG_PYENV_ROOT"
-	unset PYENV_INIT
+	rm -rf "$PYENV_INIT_LOCK"
 	# shellcheck disable=SC1090
 	source "$HOME/.bashrc.d/"*-python
 	# pyenv-rehash && PYENV_VERSION="$ver" pip install --upgrade pip

--- a/chunks/lang-python/pyenv.d/rehash/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/rehash/gitpod.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 shopt -s nullglob
 gitpod_shims=()
-for file in "$GP_PYENV_MIRROR"/user/*/bin/*; do {
+for file in "$PYENV_MIRROR"/user/*/bin/*; do {
 	gitpod_shims+=("${file##*/}")
 }; done 2>/dev/null
 make_shims "${gitpod_shims[@]}"

--- a/chunks/lang-python/pyenv.d/uninstall/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/uninstall/gitpod.bash
@@ -2,7 +2,7 @@
 function fake_cleanup() { # function read()
 	# builtin read "$@";
 	# if [[ "${REPLY,,}" =~ ^y ]]; then {
-	MIRROR_VER_DIR="$GP_PYENV_FAKEROOT/versions/${VERSION_NAME}"
+	MIRROR_VER_DIR="$PYENV_FAKEROOT/versions/${VERSION_NAME}"
 	# ORIG_VER_DIR="$PYENV_ROOT/versions/$VERSION_NAME"
 	if test -e "$MIRROR_VER_DIR"; then {
 		if mountpoint -q "$MIRROR_VER_DIR"; then {

--- a/chunks/lang-python/pyenv.d/which/gitpod.bash
+++ b/chunks/lang-python/pyenv.d/which/gitpod.bash
@@ -3,7 +3,7 @@
 ## Give user variant higher priority
 # shellcheck disable=SC2154
 for version in "${versions[@]}"; do {
-	_check_upath="${GP_PYENV_MIRROR}/user/${version}/bin/$PYENV_COMMAND"
+	_check_upath="${PYENV_MIRROR}/user/${version}/bin/$PYENV_COMMAND"
 	if test -x "$_check_upath"; then {
 		# shellcheck disable=SC2034
 		PYENV_COMMAND_PATH="$_check_upath"
@@ -17,7 +17,7 @@ for version in "${versions[@]}"; do {
 function pyenv-prefix {
 	# Add user prefix paths when called by pyenv-prefix
 	if test "${BASH_SOURCE[1]}" == "$PYENV_ROOT/libexec/pyenv-whence"; then {
-		local target="${GP_PYENV_MIRROR}/user/$1"
+		local target="${PYENV_MIRROR}/user/$1"
 		if test -e "$target"; then {
 			echo "$target"
 			return

--- a/chunks/lang-python/python_hook.bash
+++ b/chunks/lang-python/python_hook.bash
@@ -5,13 +5,13 @@
 function pyenv_gitpod_init() {
 	if test -e "$GITPOD_REPO_ROOT"; then {
 		export PYENV_HOOK_PATH="$HOME/.gp_pyenv.d"
-		export GP_PYENV_MIRROR="/workspace/.pyenv_mirror"
-		export GP_PYENV_FAKEROOT="$GP_PYENV_MIRROR/fakeroot"
-		export PYTHONUSERBASE="$GP_PYENV_MIRROR/user/current"
+		export PYENV_MIRROR="/workspace/.pyenv_mirror"
+		export PYENV_FAKEROOT="$PYENV_MIRROR/fakeroot"
+		export PYTHONUSERBASE="$PYENV_MIRROR/user/current"
 		export PYTHONUSERBASE_VERSION_FILE="${PYTHONUSERBASE%/*}/.mounted_version"
-		export PIP_CACHE_DIR="$GP_PYENV_MIRROR/pip_cache"
+		export PIP_CACHE_DIR="$PYENV_MIRROR/pip_cache"
 
-		if test ! -v GP_PYENV_INIT; then {
+		if test ! -v PYENV_INIT; then {
 
 			function vscode::add_settings() (
 				# From https://github.com/axonasif/dotfiles/blob/main/src/utils/common.sh
@@ -59,7 +59,7 @@ function pyenv_gitpod_init() {
 			local target version_dir
 			(
 				shopt -s nullglob
-				for version_dir in "$GP_PYENV_FAKEROOT/versions/"*; do {
+				for version_dir in "$PYENV_FAKEROOT/versions/"*; do {
 					target="$PYENV_ROOT/versions/${version_dir##*/}"
 					mkdir -p "$target" 2>/dev/null
 					if ! mountpoint -q "$target" && ! sudo mount --bind "$version_dir" "$target" 2>/dev/null; then {
@@ -70,7 +70,7 @@ function pyenv_gitpod_init() {
 			)
 
 			# Persistent `pyenv global` version
-			local p_version_file="$GP_PYENV_FAKEROOT/version"
+			local p_version_file="$PYENV_FAKEROOT/version"
 			local o_version_file="$PYENV_ROOT/version"
 			if test ! -e "$p_version_file"; then {
 				mkdir -p "${p_version_file%/*}"
@@ -93,10 +93,10 @@ function pyenv_gitpod_init() {
 				}
 			JSON
 
-		}; fi && export GP_PYENV_INIT=true
+		}; fi && export PYENV_INIT=true
 
 		# Poetry customizations
-		export POETRY_CACHE_DIR="$GP_PYENV_MIRROR/poetry"
+		export POETRY_CACHE_DIR="$PYENV_MIRROR/poetry"
 	}; fi
 }
 

--- a/chunks/lang-python/python_hook.bash
+++ b/chunks/lang-python/python_hook.bash
@@ -11,6 +11,7 @@ function pyenv_gitpod_init() {
 		export PYTHONUSERBASE_VERSION_FILE="${PYTHONUSERBASE%/*}/.mounted_version"
 		export PIP_CACHE_DIR="$PYENV_MIRROR/pip_cache"
 		export PYENV_INIT_LOCK="/tmp/.pyenv_init.lock"
+		local pyenv_init_done="$PYENV_INIT_LOCK/done"
 
 		if mkdir "$PYENV_INIT_LOCK" 2>/dev/null; then {
 
@@ -22,7 +23,7 @@ function pyenv_gitpod_init() {
 				for vscode_machine_settings_file in "$@"; do {
 					# Create the vscode machine settings file if it doesnt exist
 					if test ! -e "$vscode_machine_settings_file"; then {
-						mkdir -p "${vscode_machine_settings_file%/*}" 2>/dev/null || return
+						mkdir -p "${vscode_machine_settings_file%/*}" || return
 						touch "$vscode_machine_settings_file"
 					}; fi
 
@@ -74,8 +75,11 @@ function pyenv_gitpod_init() {
 			pyenv global 1>/dev/null
 
 			# Set $HOME/.pyenv/shims/python as the default Interpreter for ms-python.python VSCode extension
-			vscode::add_settings "/workspace/.vscode-remote/data/Machine/settings.json" "$HOME/.vscode-server/data/Machine/settings.json"
+			vscode::add_settings "/workspace/.vscode-remote/data/Machine/settings.json" "$HOME/.vscode-server/data/Machine/settings.json" >/dev/null 2>&1
 
+			touch "$pyenv_init_done"
+		}; else {
+			until test -e "$pyenv_init_done"; do sleep 0.2; done
 		}; fi
 
 		# Poetry customizations

--- a/chunks/lang-python/userbase.bash
+++ b/chunks/lang-python/userbase.bash
@@ -12,7 +12,7 @@ if test -e "${GITPOD_REPO_ROOT:-}" && test "${BASH_SOURCE[1]}" == "$PYENV_ROOT/l
 	# }; fi
 	pyenv_version="${PYENV_VERSION%%:*}"
 	system_python_userbase="$PYTHONUSERBASE"
-	userbase_dir="$GP_PYENV_MIRROR/user"
+	userbase_dir="$PYENV_MIRROR/user"
 	versioned_python_userbase_dir="$userbase_dir/$pyenv_version"
 	mounted_version_file="$PYTHONUSERBASE_VERSION_FILE"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The new `bash` version `5.1.16` on Ubuntu jammy possibly broke something with the `read` command we had in the python hook file. This also does some tiny optimizations and refactoring. Ubuntu focal had `bash` version `5.0.17`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open https://gitpod.io/#https://github.com/axonasif/gitpod
- Check if commands from gitpod tasks are being executed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix python bash hook for ubuntu jammy
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
