### PR TITLE
fix: remove `use_pty` option for sudo

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,6 +36,9 @@ ENV LANG=en_US.UTF-8
 ### Update and upgrade the base image ###
 RUN upgrade-packages
 
+## Remove `use_pty` option for sudo.
+RUN sed -i '/Defaults\tuse_pty/d' /etc/sudoers
+
 ### Git ###
 RUN add-apt-repository -y ppa:git-core/ppa
 RUN install-packages git git-lfs

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,9 +36,6 @@ ENV LANG=en_US.UTF-8
 ### Update and upgrade the base image ###
 RUN upgrade-packages
 
-## Remove `use_pty` option for sudo.
-RUN sed -i '/Defaults\tuse_pty/d' /etc/sudoers
-
 ### Git ###
 RUN add-apt-repository -y ppa:git-core/ppa
 RUN install-packages git git-lfs
@@ -46,8 +43,8 @@ RUN install-packages git git-lfs
 ### Gitpod user ###
 # '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
-    # passwordless sudo for users in the 'sudo' group
-    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers \
+    # Remove `use_pty` option and enable passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e '/Defaults\tuse_pty/d' -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers \
     # To emulate the workspace-session behavior within dazzle build env
     && mkdir /workspace && chown -hR gitpod:gitpod /workspace
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Having `use_pty` option enabled from the `sudoers` config has unwanted side effects for background scripts starting from `.bashrc` that calls `sudo`, it was introduced in ubuntu jammy. It doesn't seem to have any security benefits in the context of Gitpod, seems very minimal _even if it does_. For more info, see:
- https://manpages.ubuntu.com/manpages/jammy/en/man5/sudoers.5.html

It mentions:
```markdown

     use_pty           If set, and sudo is running in a terminal, the command will be run in a
                       pseudo-terminal (even if no I/O logging is being done).  If the sudo
                       process is not attached to a terminal, use_pty has no effect.

                       A malicious program run under sudo may be capable of injecting commands
                       into the user's terminal or running a background process that retains
                       access to the user's terminal device even after the main program has
                       finished executing.  By running the command in a separate pseudo-terminal,
                       this attack is no longer possible.  **This flag is off by default.**
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Required for https://github.com/gitpod-io/workspace-images/pull/1062

## How to test
<!-- Provide steps to test this PR -->
- Open https://gitpod.io/#https://github.com/axonasif/gitpod
- Check if `sudo` works normally by running any command
- If you want, you can check if the line containing `use_pty` option was removed: `sudo grep use_pty /etc/sudoers`, it should print nothing.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix: remove `use_pty` option for sudo
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
