### PR TITLE
Limit parallelism for skopeo copy / upload to GAR

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -105,26 +105,36 @@ jobs:
 
       - name: 📋 Copy images with tag in the Artifact Registry
         run: |
+          upload_image() {
+              local IMAGE_TAG=$1
+
+              (sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers --retry-times=2 \
+              docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
+              docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:${{ env.TIMESTAMP_TAG }} &)
+
+              (sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers  --retry-times=2 \
+              docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
+              docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:latest &)
+
+              wait
+          }
+
+          MAX_PARALLEL=10
+          declare -a UPLOAD_PIDS=()
           IMAGE_TAGS=$(cat .github/sync-containers.yml | yq '.sync.images."workspace-base-images"|join(" ")' -r)
-          COPY_JOBS_PIDS=""
-          for IMAGE_TAG in $IMAGE_TAGS;
-          do
-            sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers \
-            docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
-            docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:${{ env.TIMESTAMP_TAG }} &
 
-            COPY_JOBS_PIDS="$COPY_JOBS_PIDS $!"
+          for image_tag in "${IMAGE_TAGS[@]}"; do
+              upload_image "$image_tag" &
 
-            sudo skopeo copy --format=oci --dest-oci-accept-uncompressed-layers \
-            docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-base-images:$IMAGE_TAG \
-            docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/workspace-$IMAGE_TAG:latest &
+              UPLOAD_PIDS+=($!)
 
-            COPY_JOBS_PIDS="$COPY_JOBS_PIDS $!"
+              if [ ${#UPLOAD_PIDS[@]} -eq $MAX_PARALLEL ]; then
+                # Wait for the first background process in the array
+                wait "${UPLOAD_PIDS[0]}"
 
-          done
-
-          for COPY_JOBS_PID in $COPY_JOBS_PIDS; do
-              wait $COPY_JOBS_PID || exit 1
+                # Remove the first element from the array
+                UPLOAD_PIDS=("${UPLOAD_PIDS[@]:1}")
+              fi
           done
 
       - name: ✍🏽 Login to Docker Hub using skopeo


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We're getting timeouts when uploading to GAR relatively quickly after dazzle build and combine.
There's no limit on the parallel uploads, let's add one to see if it helps.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates WKS-164

## How to test
<!-- Provide steps to test this PR -->
merge to main :crossed_fingers: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
