### PR TITLE
Add new gitpod-dev image

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -33,3 +33,4 @@
     workspace-java-17: "20.*"
     workspace-yugabytedb: "20.*"
     workspace-yugabytedb-preview: "20.*"
+    workspace-gitpod-dev: "20.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -30,3 +30,4 @@ sync:
     - java-17
     - yugabytedb
     - yugabytedb-preview
+    - gitpod-dev

--- a/buildkitd.toml
+++ b/buildkitd.toml
@@ -1,4 +1,10 @@
 root = "/workspace/buildkit"
 
 [worker.oci]
-gckeepstorage = 40000
+  enabled = true
+  platforms = [ "linux/amd64" ]
+  snapshotter = "auto"
+  rootless = false
+  gc = true
+  gckeepstorage = 40000
+  max-parallelism = 16

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -5,6 +5,15 @@ combiner:
         - dep-cacert-update
         - tool-docker
         - tool-tailscale
+    - name: gitpod-dev
+      ref:
+      - base
+      chunks:
+        - lang-c
+        - lang-go:1.20
+        - lang-java:11
+        - lang-node:18
+        - tool-brew
     - name: c
       ref:
       - base
@@ -178,16 +187,6 @@ combiner:
         - tool-nginx
         - tool-nix:2.11.0
         - tool-yugabytedb:2.15
-    - name: gitpod-dev
-      ref:
-      - base
-      chunks:
-        - lang-c
-        - lang-go:1.20
-        - lang-java:11
-        - lang-node:18
-        - lang-python:3.11
-        - tool-brew
   envvars:
     - name: PATH
       action: merge-unique

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -178,6 +178,16 @@ combiner:
         - tool-nginx
         - tool-nix:2.11.0
         - tool-yugabytedb:2.15
+    - name: gitpod-dev
+      ref:
+      - base
+      chunks:
+        - lang-c
+        - lang-go:1.20
+        - lang-java:11
+        - lang-node:18
+        - lang-python:3.11
+        - tool-brew
   envvars:
     - name: PATH
       action: merge-unique


### PR DESCRIPTION
## Description

Do not use workspace-full for gitpod development to reduce the size and avoid 3m pulling images in CI


/hold
