### PR TITLE
Upgrade Homebrew to 4.0.28

### DIFF
--- a/chunks/tool-brew/Dockerfile
+++ b/chunks/tool-brew/Dockerfile
@@ -4,7 +4,7 @@ FROM ${base}
 USER gitpod
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=4
+ENV TRIGGER_REBUILD=5
 
 RUN mkdir ~/.cache && /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin/:$PATH


### PR DESCRIPTION
## Description
Related to https://github.com/Homebrew/homebrew-bundle/issues/1227, current Homebrew version is outdated and failing with some specific taps.

Upgrading Homebrew to the latest version (`4.0.28`) solves the problem.

## Related Issue(s)

https://github.com/Homebrew/homebrew-bundle/issues/1227

## How to test
1. Create a Brew bundle file with the following content:

```yaml
tap "homebrew/bundle"
tap "homebrew/core"

brew "zplug"
```

2. Run `brew bundle install`

3. Installation should succeed

## Documentation
* No

/hold
