### PR TITLE
[.github] add hints to test locally and prevent parsing failures for the first run

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -38,18 +38,20 @@ jobs:
         run: |
           # Generate a temporal file to store skopeo auth
           SKOPEO_AUTH_FILE=$(mktemp)
+          # to test locally
+          # export GITHUB_ENV=$(mktemp)
           echo "SKOPEO_AUTH_FILE=${SKOPEO_AUTH_FILE}" >> $GITHUB_ENV
           # Build a fake skopeo script to run a container
-          cat <<'EOF' > /usr/local/bin/skopeo
+          cat <<EOF | sudo tee /usr/local/bin/skopeo > /dev/null
           #/bin/bash
 
-          docker run --rm -v $SKOPEO_AUTH_FILE:/skopeo.auth -e REGISTRY_AUTH_FILE=/skopeo.auth quay.io/skopeo/stable:v1.12.0 "$@"
+          docker run --rm -v $SKOPEO_AUTH_FILE:/skopeo.auth -e REGISTRY_AUTH_FILE=/skopeo.auth quay.io/skopeo/stable:v1.12.0 "\$@"
           EOF
 
-          chmod +x /usr/local/bin/skopeo
+          sudo chmod +x /usr/local/bin/skopeo
 
-          # delete the file, so skopeo doesn't try parsing it, initially
-          rm "${SKOPEO_AUTH_FILE}"
+          # don't fail parsing the file while it contains empty creds the first time
+          echo "{}" > $SKOPEO_AUTH_FILE
 
       - name: ☁️ Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1


### PR DESCRIPTION
## How to test

```
export GITHUB_ENV=$(mktemp)
SKOPEO_AUTH_FILE=$(mktemp)

cat <<EOF | sudo tee /usr/local/bin/skopeo > /dev/null
#/bin/bash

docker run --rm -v $SKOPEO_AUTH_FILE:/skopeo.auth -e REGISTRY_AUTH_FILE=/skopeo.auth quay.io/skopeo/stable:v1.12.0 "\$@"
EOF

sudo chmod +x /usr/local/bin/skopeo

echo "{}" > $SKOPEO_AUTH_FILE

skopeo login -u oauth2accesstoken --password=foo europe-docker.pkg.dev
```

Should yield:
```
time="2023-07-12T18:38:13Z" level=fatal msg="logging into \"europe-docker.pkg.dev\": invalid username/password"
```