### PR TITLE
[.github] one more time, skopeo

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -90,7 +90,8 @@ jobs:
           IMAGES=$(cat .github/promote-images.yml | yq '."europe-docker.pkg.dev/gitpod-artifacts/docker-dev"."images-by-tag-regex"|keys[]' -r)
           for IMAGE in $IMAGES;
           do
-            sudo -E skopeo copy --format=oci --dest-oci-accept-uncompressed-layers \
+            sudo -E skopeo copy --src-authfile=/skopeo.auth/auth --dest-authfile=/skopeo.auth/auth \
+            --format=oci --dest-oci-accept-uncompressed-layers \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/$IMAGE:latest \
             docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest
           done


### PR DESCRIPTION
The job is failing on [skopeo copy](https://github.com/gitpod-io/workspace-images/actions/runs/5536552981/jobs/10104367297#step:9:27).

The `authfile` flag is okay:
```
--authfile string                       path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json (default "/skopeo.auth/auth")
```

But the `src-authfile` and `dest-authfile` are not:
```
--dest-authfile string                  path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
--src-authfile string                   path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
```

