### PR TITLE
[.github] fix typo for `skopeo copy`

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -90,7 +90,7 @@ jobs:
           IMAGES=$(cat .github/promote-images.yml | yq '."europe-docker.pkg.dev/gitpod-artifacts/docker-dev"."images-by-tag-regex"|keys[]' -r)
           for IMAGE in $IMAGES;
           do
-            sudo -E skopeo copy --src-authfile=/skopeo.auth/auth --dest-authfile=/skopeo.auth/auth \
+            sudo -E skopeo copy --src-authfile /skopeo.auth/auth --dest-authfile /skopeo.auth/auth \
             --format=oci --dest-oci-accept-uncompressed-layers \
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/$IMAGE:latest \
             docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest


### PR DESCRIPTION
`skopeo copy` doesn't appear to be using the values we set for `REGISTRY_AUTH_FILE` (at least according to the generated `--help` output).

Also, the syntax for `src-authfile` and `dest-authfile` is wrong here / doesn't match their docs.