### PR TITLE
[.github] fix the bind mount syntax

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -37,24 +37,24 @@ jobs:
       - name: 🔆 Setup skopeo
         run: |
           # Generate a temporal file to store skopeo auth
-          SKOPEO_AUTH_FILE=$(mktemp -d)
+          SKOPEO_AUTH_DIR=$(mktemp -d)
           # to test locally
           # export GITHUB_ENV=$(mktemp)
-          echo "SKOPEO_AUTH_FILE=${SKOPEO_AUTH_FILE}/auth" >> $GITHUB_ENV
+          echo "SKOPEO_AUTH_DIR=${SKOPEO_AUTH_DIR}" >> $GITHUB_ENV
           # Build a fake skopeo script to run a container
           cat <<EOF | sudo tee /usr/local/bin/skopeo > /dev/null
           #/bin/bash
 
           docker run --rm \
-            -v $SKOPEO_AUTH_FILE=$HOME/.docker \
-            -e REGISTRY_AUTH_FILE=$HOME/.docker/auth \
+            -v $SKOPEO_AUTH_DIR:/skopeo.auth \
+            -e REGISTRY_AUTH_FILE=/skopeo.auth/auth \
             quay.io/skopeo/stable:v1.12.0 "\$@"
           EOF
 
           sudo chmod +x /usr/local/bin/skopeo
 
           # don't fail parsing the file while it contains empty creds the first time
-          echo "{}" > $SKOPEO_AUTH_FILE/auth
+          echo "{}" > $SKOPEO_AUTH_DIR/auth
 
       - name: ☁️ Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1.1.1
@@ -71,7 +71,7 @@ jobs:
 
       - name: ✍🏽 Login to GAR using skopeo
         env:
-          SKOPEO_AUTH_FILE: ${{env.SKOPEO_AUTH_FILE}}
+          SKOPEO_AUTH_DIR: ${{env.SKOPEO_AUTH_DIR}}
         run: |
           sudo -E skopeo login -u oauth2accesstoken --password=${{ steps.auth.outputs.access_token }} ${{env.GAR_IMAGE_REGISTRY}}
 
@@ -79,13 +79,13 @@ jobs:
         env:
           docker_user: ${{ secrets.DOCKERHUB_USER_NAME }}
           docker_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-          SKOPEO_AUTH_FILE: ${{env.SKOPEO_AUTH_FILE}}
+          SKOPEO_AUTH_DIR: ${{env.SKOPEO_AUTH_DIR}}
         run: |
           sudo -E skopeo login -u ${{ env.docker_user }} --password=${{ env.docker_password }} ${{ env.DH_IMAGE_REGISTRY }}
 
       - name: 🐳 Sync latest tag of images to Docker Hub
         env:
-          SKOPEO_AUTH_FILE: ${{env.SKOPEO_AUTH_FILE}}
+          SKOPEO_AUTH_DIR: ${{env.SKOPEO_AUTH_DIR}}
         run: |
           IMAGES=$(cat .github/promote-images.yml | yq '."europe-docker.pkg.dev/gitpod-artifacts/docker-dev"."images-by-tag-regex"|keys[]' -r)
           for IMAGE in $IMAGES;


### PR DESCRIPTION
Use a colon, not equals. D'oh! We weren't persisting to the authfile after login...

To test in a Gitpod workspace:
```
sudo rm /usr/local/bin/skopeo
docker container prune -f
export GITHUB_ENV=$(mktemp)
SKOPEO_AUTH_DIR=$(mktemp -d)
echo "{}" > $SKOPEO_AUTH_DIR/auth
echo "SKOPEO_AUTH_DIR=${SKOPEO_AUTH_DIR}" >> $GITHUB_ENV

cat <<EOF | sudo tee /usr/local/bin/skopeo > /dev/null
#/bin/bash

docker run --rm \
-v $SKOPEO_AUTH_DIR:/skopeo.auth \
-e REGISTRY_AUTH_FILE=/skopeo.auth/auth \
quay.io/skopeo/stable:v1.12.0 "\$@"
EOF

sudo chmod +x /usr/local/bin/skopeo

# use single quotes, to avoid characters that do expansion
skopeo login -v -u <username> --password='<password>' docker.io
sudo cat $SKOPEO_AUTH_DIR/auth
```