### PR TITLE
[github] fix push-main.yml and `skopeo sync`

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -63,8 +63,12 @@ jobs:
           cat <<EOF | sudo tee /usr/local/bin/skopeo > /dev/null
           #/bin/bash
 
+          PROMOTE_IMAGES=$(mktemp -d)
+          cp .github/promote-images.yml "${PROMOTE_IMAGES}"
+
           docker run --rm \
             -v "${SKOPEO_AUTH_DIR}":/skopeo.auth \
+            -v "${PROMOTE_IMAGES}":/.github \
             -e REGISTRY_AUTH_FILE=/skopeo.auth/auth \
             quay.io/skopeo/stable:v"${SKOPEO_VERSION}" "\$@"
           EOF


### PR DESCRIPTION
The container that we're preparing to run skopeo in [needs](https://github.com/gitpod-io/workspace-images/actions/runs/5543383131/jobs/10119315364#step:18:28) to also include a copy of the promote-images.yml file for `skopeo sync`.