### PR TITLE
[.github] fix path associated with push-main.yml and `skopeo sync`

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -64,7 +64,7 @@ jobs:
           #/bin/bash
 
           PROMOTE_IMAGES=$(mktemp -d)
-          cp .github/promote-images.yml "${PROMOTE_IMAGES}"
+          cp "${GITHUB_WORKSPACE}/.github/promote-images.yml" "${PROMOTE_IMAGES}"
 
           docker run --rm \
             -v "${SKOPEO_AUTH_DIR}":/skopeo.auth \
@@ -200,4 +200,4 @@ jobs:
             sudo -E skopeo sync \
             --src yaml \
             --dest docker \
-            .github/promote-images.yml "${DH_IMAGE_REGISTRY}/gitpod"
+            /.github/promote-images.yml "${DH_IMAGE_REGISTRY}/gitpod"


### PR DESCRIPTION
Oops, the path wasn't absolute in the step, and now that we're using a bind mount, this would help a lot.

Relates to WKS-306