### PR TITLE
[.github] fix push-main.yml and upload to GAR

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -148,9 +148,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          IFS=' ' read -r -a IMAGE_TAGS < <(yq '.sync.images."workspace-base-images"|join(" ")' .github/sync-containers.yml)
-          UPLOADS=$(printf "./.github/workflows/push-main/upload_image.sh %s\n" "${IMAGE_TAGS[@]}")
-          echo "${UPLOADS}" | xargs -0 -I CMD -P 10 -n 1 \
+          IFS=' ' read -r -a IMAGE_TAGS_ARR < <(yq '.sync.images."workspace-base-images"|join(" ")' ./.github/sync-containers.yml)
+          UPLOADS_STRING=""
+          for IMAGE_TAG in "${IMAGE_TAGS_ARR[@]}"; do
+              UPLOADS_STRING+=$(printf "./.github/workflows/push-main/upload_image.sh %s%s" ${IMAGE_TAG}'\n')
+          done
+          echo -e "${UPLOADS_STRING}" | xargs -0 -I CMD -P 10 -n 1 \
           env SKOPEO_AUTH_DIR="${SKOPEO_AUTH_DIR}" GAR_IMAGE_REGISTRY="${GAR_IMAGE_REGISTRY}" TIMESTAMP_TAG="${TIMESTAMP_TAG}" SKOPEO_SYNC_FILES="${SKOPEO_SYNC_FILES}" \
           bash -c CMD --
 

--- a/.github/workflows/push-main/upload_image.sh
+++ b/.github/workflows/push-main/upload_image.sh
@@ -7,11 +7,11 @@ IMAGE_TAG=$1
 echo "Uploading ${IMAGE_TAG} at $(date -u +'%Y-%m-%d %H:%M:%S')"
 
 # upload timestamped image
-echo sudo -E skopeo copy --format=oci --dest-oci-accept-uncompressed-layers --retry-times=2 \
+sudo -E skopeo copy --format=oci --dest-oci-accept-uncompressed-layers --retry-times=2 \
 	"docker://${GAR_IMAGE_REGISTRY}/gitpod-artifacts/docker-dev/workspace-base-images:${IMAGE_TAG}" \
 	"docker://${GAR_IMAGE_REGISTRY}/gitpod-artifacts/docker-dev/workspace-${IMAGE_TAG}:${TIMESTAMP_TAG}"
 
 # upload latest image
-echo sudo -E skopeo copy --format=oci --dest-oci-accept-uncompressed-layers --retry-times=2 \
+sudo -E skopeo copy --format=oci --dest-oci-accept-uncompressed-layers --retry-times=2 \
 	"docker://${GAR_IMAGE_REGISTRY}/gitpod-artifacts/docker-dev/workspace-base-images:${IMAGE_TAG}" \
 	"docker://${GAR_IMAGE_REGISTRY}/gitpod-artifacts/docker-dev/workspace-${IMAGE_TAG}:latest"


### PR DESCRIPTION
* push-main.yml: produce a viable command string for each image we'd like to upload
* upload_image.sh: was echoing (oops), instead of actually uploading

This can be tested by executing `./foo.sh` in https://gitpod.io#snapshot/c862c9e3-e210-4498-aa7d-5d798c3cdd5e