### PR TITLE
[.github] rewrite parsing of sync-containers to work with yq 3

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -137,6 +137,7 @@ jobs:
 
       - name: 🔧 Setup copy tools
         run: |
+          # this installs yq 3
           sudo pip3 install yq
 
       - name: 📋 Copy images with tag in the Artifact Registry
@@ -148,7 +149,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          IFS=' ' read -r -a IMAGE_TAGS_ARR < <(yq '.sync.images."workspace-base-images"|join(" ")' ./.github/sync-containers.yml)
+          IFS=$'\n' read -r -d '' -a IMAGE_TAGS_ARR < <(yq -r '.sync.images."workspace-base-images"[]' ./.github/sync-containers.yml && printf '\0')
           UPLOADS_STRING=""
           for IMAGE_TAG in "${IMAGE_TAGS_ARR[@]}"; do
               UPLOADS_STRING+=$(printf "./.github/workflows/push-main/upload_image.sh %s%s" ${IMAGE_TAG}'\n')


### PR DESCRIPTION
🤦we're using yq 3, not yq 4, this explains why it worked fine in a Gitpod workspace, because I initially used `brew install yq` instead of `sudo pip3 install yq` to install yq.