### PR TITLE
Update docker-compose

### DIFF
--- a/chunks/tool-docker/Dockerfile
+++ b/chunks/tool-docker/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor
     && apt update \
     && install-packages docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
-RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.4.1/docker-compose-linux-$(uname -m) \
+RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-linux-$(uname -m) \
     && chmod +x /usr/local/bin/docker-compose && mkdir -p /usr/local/lib/docker/cli-plugins && \
     ln -s /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
 


### PR DESCRIPTION
## Description

Upgrades compose to https://github.com/docker/compose/releases/tag/v2.20.2. Should also update buildx and Docker itself.

## Related Issue(s)

An attempt to address EXP-338

## How to test

