### PR TITLE
Drop support for Go 19, update Go 20 and introduce Go 21

### DIFF
--- a/chunks/lang-go/chunk.yaml
+++ b/chunks/lang-go/chunk.yaml
@@ -1,7 +1,7 @@
 variants:
-  - name: "1.19"
-    args:
-      GO_VERSION: 1.19.11
   - name: "1.20"
     args:
-      GO_VERSION: 1.20.6
+      GO_VERSION: 1.20.7
+  - name: "1.21"
+    args:
+      GO_VERSION: 1.21.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -10,7 +10,7 @@ combiner:
       - base
       chunks:
         - lang-c
-        - lang-go:1.20
+        - lang-go:1.21
         - lang-java:11
         - lang-node:18
         - tool-brew


### PR DESCRIPTION
This PR removes the unused golang variant with version 19. It updates Go 20 to patch 7 and adds the brand new Go 21 release to our gitpod dev image.