### PR TITLE
Update Dive to `v0.11.0`

### DIFF
--- a/chunks/tool-docker/Dockerfile
+++ b/chunks/tool-docker/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compos
     ln -s /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
 
 # https://github.com/wagoodman/dive
-RUN curl -o /tmp/dive.deb -fsSL https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_linux_amd64.deb \
+RUN curl -o /tmp/dive.deb -fsSL https://github.com/wagoodman/dive/releases/download/v0.11.0/dive_0.11.0_linux_amd64.deb \
     && apt install /tmp/dive.deb \
     && rm /tmp/dive.deb
 


### PR DESCRIPTION
## Description
Properly update Dive to its latest version.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

