### PR TITLE
[skopeo] fix skopeo version

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -22,7 +22,7 @@ jobs:
       GAR_IMAGE_REGISTRY: europe-docker.pkg.dev
       DH_IMAGE_REGISTRY: registry.hub.docker.com
       IAM_SERVICE_ACCOUNT: workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com
-      SKOPEO_VERSION: 1.12.0
+      SKOPEO_VERSION: 1
 
     steps:
       - name: 📥 Checkout workspace-images

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -38,7 +38,7 @@ jobs:
       IAM_SERVICE_ACCOUNT: workspace-images-gha-sa@gitpod-artifacts.iam.gserviceaccount.com
       DAZZLE_VERSION: 0.1.17
       BUILDKIT_VERSION: 0.12.1
-      SKOPEO_VERSION: 1.12.0
+      SKOPEO_VERSION: 1
 
     steps:
       - name: 📥 Checkout workspace-images


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
quay.io only has the latest major, minor, and patch versions available

https://quay.io/repository/skopeo/stable

We were using 1.12, but, 1.13 is newer. Switching to major version of 1, to avoid future thrash when minor and patch versions change

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
Run a job dependent on skopeo

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
