### PR TITLE
[.github] automate production release

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -12,8 +12,9 @@ jobs:
   # Click New environment, set the name production, and click Configure environment.
   # Check the "Required reviewers" box and enter at least one user or team name.
   promote-latest:
+    if: (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
-    environment: "production-restricted"
+    environment: "production"
     permissions:
       contents: "read"
       id-token: "write"
@@ -97,3 +98,29 @@ jobs:
             docker://${{ env.GAR_IMAGE_REGISTRY }}/gitpod-artifacts/docker-dev/$IMAGE:latest \
             docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest
           done
+  notify:
+    needs: promote-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: The release was successful
+        id: slack
+        if: needs.promote-latest.result == 'success'
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "The release was successful :rocket:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.RELEASE_NOTIFY_WEBHOOK }}
+      - name: The release was not successful
+        id: slack
+        if: needs.promote-latest.result != 'success'
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "${{ format('The release had trouble :construction:, the result was: {0}', needs.promote-latest.result) }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.RELEASE_NOTIFY_WEBHOOK }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* limit promote-latest to schedule (which uses main) or workflow_dispatch (but, limit it to main)
* notify in Slack when releases are done
* this avoids the `production-restricted` environment, which required a human to approve the release

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
Run the action manually, it should notify in `#feature-workspace-images` with success or the failure and actual status.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
