### PR TITLE
[.github] don't skip notify on failure of dependent jobs

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -99,7 +99,7 @@ jobs:
             docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest
           done
   notify:
-    if: always()
+    if: always() && ((github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
     needs: promote-latest
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -99,6 +99,7 @@ jobs:
             docker://${{ env.DH_IMAGE_REGISTRY }}/gitpod/$IMAGE:latest
           done
   notify:
+    if: always()
     needs: promote-latest
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Looks like there's runner trouble, or, a need to upgrade to v4 for actions/checkout.

Ref: https://github.com/actions/checkout/issues/1448

Either way, we should notify when this job is not successful.