### PR TITLE
Create workspace image for tool-bun chunk

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -31,3 +31,4 @@
     workspace-yugabytedb: "2023.*"
     workspace-yugabytedb-preview: "2023.*"
     workspace-gitpod-dev: "2023.*"
+    workspace-bun: "2023.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -28,3 +28,4 @@ sync:
     - yugabytedb
     - yugabytedb-preview
     - gitpod-dev
+    - bun

--- a/chunks/tool-bun/.bunfig.toml
+++ b/chunks/tool-bun/.bunfig.toml
@@ -1,0 +1,10 @@
+[install]
+# where `bun install --global` installs packages
+globalDir = "/workspace/.bun/install/global"
+
+# where globally-installed package bins are linked
+globalBinDir = "/workspace/.bun/bin"
+
+[install.cache]
+# the directory to use for the cache
+dir = "/workspace/.bun/install/cache"

--- a/chunks/tool-bun/Dockerfile
+++ b/chunks/tool-bun/Dockerfile
@@ -1,0 +1,11 @@
+ARG base
+FROM ${base}
+
+ENV BUN_INSTALL="${HOME}/.bun"
+ENV PATH="${BUN_INSTALL}:${PATH}"
+
+# Install bun
+RUN curl -fsSL https://bun.sh/install | bash
+
+# Custom bug config for Gitpod
+COPY --chown=gitpod:gitpod .bunfig.toml "$HOME"

--- a/chunks/tool-bun/Dockerfile
+++ b/chunks/tool-bun/Dockerfile
@@ -2,7 +2,7 @@ ARG base
 FROM ${base}
 
 ENV BUN_INSTALL="${HOME}/.bun"
-ENV PATH="${BUN_INSTALL}:${PATH}"
+ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
 # Install bun
 RUN curl -fsSL https://bun.sh/install | bash

--- a/chunks/tool-bun/Dockerfile
+++ b/chunks/tool-bun/Dockerfile
@@ -5,7 +5,7 @@ ENV BUN_INSTALL="${HOME}/.bun"
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
 # Install bun
-RUN curl -fsSL https://bun.sh/install | bash
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.0.2"
 
 # Custom bug config for Gitpod
 COPY --chown=gitpod:gitpod .bunfig.toml "$HOME"

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -44,7 +44,6 @@ combiner:
         - tool-brew
         - tool-nginx
         - tool-nix:2.11.0
-        - tool-bun
     - name: full-vnc
       ref:
       - full
@@ -168,6 +167,11 @@ combiner:
         - tool-nginx
         - tool-nix:2.11.0
         - tool-yugabytedb:2.19
+    - name: bun
+      ref:
+      - full
+      chunks:
+        - tool-bun
   envvars:
     - name: PATH
       action: merge-unique

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -44,6 +44,7 @@ combiner:
         - tool-brew
         - tool-nginx
         - tool-nix:2.11.0
+        - tool-bun
     - name: full-vnc
       ref:
       - full

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -169,7 +169,7 @@ combiner:
         - tool-yugabytedb:2.19
     - name: bun
       ref:
-      - full
+      - base
       chunks:
         - tool-bun
   envvars:

--- a/tests/lang-python.yaml
+++ b/tests/lang-python.yaml
@@ -47,7 +47,7 @@
   command:
     [
       ver=2.1.3; origdir="$PYENV_ROOT/versions/$ver" newVdir="/workspace/.pyenv_mirror/fakeroot/versions";
-      pyenv install $ver && test -e "$origdir" && mkdir -p "$newVdir" && mv "$origdir" "$newVdir" && GITPOD_REPO_ROOT=/workspace bash -ci "pyenv install -s $ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay Gitpod",
+      pyenv install $ver && test -e "$origdir" && mkdir -p "$newVdir" && mv "$origdir" "$newVdir" && GITPOD_REPO_ROOT=/workspace bash -ci "pyenv install -s $ver && pip install cowsay && pyenv global $(pyenv version-name) $ver && cowsay -t Gitpod",
     ]
   assert:
     - status == 0

--- a/tests/tool-bun.yaml
+++ b/tests/tool-bun.yaml
@@ -1,0 +1,4 @@
+- desc: "bun binary should work"
+  command: [bun, --version]
+  assert:
+  - status == 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[Bun](https://bun.sh/) serves as a drop-in replacement for Node, and its binary (bun) is quite lightweight. Recently, some community members have asked if we could include it in our default image. And recently, bun hit the `v1.0` milestone, so it's probably the best time to add it, vercel also added it: https://vercel.com/changelog/bun-install-is-now-supported-with-zero-configuration

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

I built the full combo and pushed to my personal dockerhub: `axonasif/workspace-full-bun`

Try here: https://gitpod.io/#https://github.com/axonasif/test/tree/bun

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
