### PR TITLE
Node 19 -> Node 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2023-10-02
+
+- For `workspace-node`, deprecate Node 19 in favor of Node 20
+
 ## 2023-09-18
 
 - Bump Rust to `1.72.0`

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -2,6 +2,6 @@ variants:
   - name: "18"
     args:
       NODE_VERSION: 18.18.0
-  - name: "19"
+  - name: "20"
     args:
-      NODE_VERSION: 19.9.0
+      NODE_VERSION: 20.8.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -64,7 +64,7 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:19
+        - lang-node:20
         - tool-chrome
     - name: node-lts
       ref:

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -20,12 +20,12 @@
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-- desc: it should yarn work
+- desc: it should have working yarn
   command: [yarn global add envinfo]
   entrypoint: [bash, -i, -c]
   assert:
   - status == 0
-- desc: it should pnpm work
+- desc: it should have working pnpm
   command: [pnpm i -g envinfo]
   entrypoint: [bash, -i, -c]
   assert:

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -4,7 +4,7 @@
   assert:
   - status == 0
   - stdout.indexOf("v18")  != -1 ||
-    stdout.indexOf("v19")  != -1
+    stdout.indexOf("v20")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
Node 19 has reached End Of Life, so we're replacing it with the soon-to-be LTS, Node 20.

- https://nodejs.dev/en/about/releases/