### PR TITLE
Update Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2023-10-09
+
+- Bump Rust to `1.73.0`
+
 ## 2023-10-06
 
 - Deprecate `gitpod/workspace-python-3.10`

--- a/chunks/lang-rust/chunk.yaml
+++ b/chunks/lang-rust/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      RUST_VERSION: 1.72.1
+      RUST_VERSION: 1.73.0


### PR DESCRIPTION
## Description

Bumps Rust to https://github.com/rust-lang/rust/releases/tag/1.73.0

