### PR TITLE
Clean go cache in `lang:go`

### DIFF
--- a/chunks/lang-go/Dockerfile
+++ b/chunks/lang-go/Dockerfile
@@ -23,7 +23,8 @@ RUN go install -v github.com/uudashr/gopkgs/cmd/gopkgs@v2 \
 && go install -v github.com/go-delve/delve/cmd/dlv@latest \
 && go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
 && go install -v golang.org/x/tools/gopls@latest \
-&& go install -v honnef.co/go/tools/cmd/staticcheck@latest
+&& go install -v honnef.co/go/tools/cmd/staticcheck@latest \
+&& go clean -cache -modcache
 
 RUN sudo rm -rf $GOPATH/src $GOPATH/pkg $HOME/.cache/go $HOME/.cache/go-build && \
     printf '%s\n' 'export GOPATH=/workspace/go' \


### PR DESCRIPTION
## Description

After we install the myriad of Go CLI tools, we are left with a hefty cache folder, which is included in the image.

This was originally described in #1146 and aims to improve the size of the image by almost a third.

## Related issues

Fixes #1146 

