### PR TITLE
bun: `v1.0.6`

### DIFF
--- a/chunks/tool-bun/chunk.yaml
+++ b/chunks/tool-bun/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      BUN_VERSION: 1.0.4
+      BUN_VERSION: 1.0.6


### PR DESCRIPTION
Skips bun ahead to v1.0.6. 

https://github.com/oven-sh/bun/releases/tag/bun-v1.0.6