### PR TITLE
Python autofix update

### DIFF
--- a/.autofix/fixers/update-lang-python.js
+++ b/.autofix/fixers/update-lang-python.js
@@ -1,28 +1,36 @@
 const os = require('os');
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
+
+function sortSemVer(arr, reverse = false) {
+  let semVerArr = arr.map(i => i.replace(/(\d+)/g, m => +m + 100000)).sort(); // +m is just a short way of converting the match to int
+  if (reverse)
+      semVerArr = semVerArr.reverse();
+
+  return semVerArr.map(i => i.replace(/(\d+)/g, m => +m - 100000))
+}
 
 exports.register = async (fixers) => {
-  const { stdout, stderr } = await exec('pyenv update 2>&1 && pyenv install --list');
-  if (stderr) {
-    throw stderr;
-  }
+  const response = await fetch("https://raw.githubusercontent.com/endoflife-date/release-data/main/releases/python.json");
+  const data = await response.json();
+
+  const versions = sortSemVer(Object.keys(data));
 
   const patchVersionReplacements = {};
-  for (const line of stdout.split('\n').slice(1,-1)) {
-    const match = line.trim().match(/^([a-z1-9\.]+-)?(\d+\.\d+\.)(\d+)$/);
+  for (const version of versions) {
+    const match = version.match(/^(\d+\.\d+)\.(\d+)$/);
     if (!match) {
       continue;
     }
-
-    const pattern = ((match[1] || '') + match[2]).replace(/\./g, '\\.') + '[0-9][0-9]*';
-    patchVersionReplacements[pattern] = match[0];
+    // Only capturing major and minor versions in the pattern
+    const segments = version.split('.');
+    const prefix = segments.slice(0, -1).join('\\.');
+    const pattern = prefix + '\\.[0-9][0-9]*';
+    patchVersionReplacements[pattern] = version;
   }
 
   fixers[0].push({
     id: 'update-lang-python',
     cmd: Object.keys(patchVersionReplacements).map(pattern => {
-        return `sed ${os.type() === 'Darwin' ? '-i "" -E' : '-i -e'} "s/\\(PYTHON_VERSION.*\\)${pattern}/\\1${patchVersionReplacements[pattern]}/g" chunks/lang-python/chunk.yaml`;
+      return `sed ${os.type() === 'Darwin' ? '-i "" -E' : '-i -e'} "s/\\(PYTHON_VERSION.*\\)${pattern}/\\1${patchVersionReplacements[pattern]}/g" chunks/lang-python/chunk.yaml`;
     }).join('\n'),
     description: 'update lang python',
   });

--- a/.autofix/fixers/update-lang-python.js
+++ b/.autofix/fixers/update-lang-python.js
@@ -1,9 +1,11 @@
 const os = require('os');
 
-function sortSemVer(arr, reverse = false) {
-  let semVerArr = arr.map(i => i.replace(/(\d+)/g, m => +m + 100000)).sort(); // +m is just a short way of converting the match to int
-  if (reverse)
-      semVerArr = semVerArr.reverse();
+// Adapted from https://stackoverflow.com/a/71331716/10199319 (CC BY-SA 4.0)
+function sortVersions(versionArray, reverse = false) {
+  let semVerArr = versionArray.map(i => i.replace(/(\d+)/g, m => +m + 100000)).sort(); // +m is just a short way of converting the match to int
+  if (reverse) {
+    semVerArr = semVerArr.reverse();
+  }
 
   return semVerArr.map(i => i.replace(/(\d+)/g, m => +m - 100000))
 }
@@ -12,7 +14,7 @@ exports.register = async (fixers) => {
   const response = await fetch("https://raw.githubusercontent.com/endoflife-date/release-data/main/releases/python.json");
   const data = await response.json();
 
-  const versions = sortSemVer(Object.keys(data));
+  const versions = sortVersions(Object.keys(data));
 
   const patchVersionReplacements = {};
   for (const version of versions) {


### PR DESCRIPTION
## Description

This changes the behavior to use https://github.com/endoflife-date/release-data/ as the source of truth for Python versions, hence removing `pyenv` as a dependency.

