### PR TITLE
bun: v1.0.21

### DIFF
--- a/chunks/tool-bun/chunk.yaml
+++ b/chunks/tool-bun/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      BUN_VERSION: 1.0.20
+      BUN_VERSION: 1.0.21


### PR DESCRIPTION
## Description
Bumps Bun to https://github.com/oven-sh/bun/releases/tag/bun-v1.0.21
