### PR TITLE
ruby: v3.3.0

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -25,6 +25,7 @@
     workspace-ruby-3.0: "2024.*"
     workspace-ruby-3.1: "2024.*"
     workspace-ruby-3.2: "2024.*"
+    workspace-ruby-3.3: "2024.*"
     workspace-rust: "2024.*"
     workspace-dotnet: "2024.*"
     workspace-dotnet-6: "2024.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -22,6 +22,7 @@ sync:
     - ruby-3.0
     - ruby-3.1
     - ruby-3.2
+    - ruby-3.3
     - rust
     - dotnet
     - dotnet-6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
-## 2024-01-05
+## 2024-01-08
 
 - Introduce `workspace-ruby-3.3`
 - Bump the Ruby version in `workspace-ruby-3.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-01-05
+
+- Introduce `workspace-ruby-3.3`
+- Bump the Ruby version in `workspace-ruby-3.3`
+
 ## 2024-01-04
 
 - Bump docker-compose to `2.23.3`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We upgraded to support [dazzle v2](https://github.com/gitpod-io/dazzle) and buil
 
 ## Summary
 
-- **Operating System**: Ubuntu 22.04.2 LTS
+- **Operating System**: Ubuntu 22.04.3 LTS
 - **OS Type**: Linux
 - **Architecture**: x86_64
 
@@ -63,6 +63,8 @@ Each contains a set of chunks: a common base, and a language, and includes Docke
 - [`gitpod/workspace-ruby-3`](https://hub.docker.com/r/gitpod/workspace-ruby-3) ✅
 - [`gitpod/workspace-ruby-3.0`](https://hub.docker.com/r/gitpod/workspace-ruby-3.0) ✅
 - [`gitpod/workspace-ruby-3.1`](https://hub.docker.com/r/gitpod/workspace-ruby-3.1) ✅
+- [`gitpod/workspace-ruby-3.2`](https://hub.docker.com/r/gitpod/workspace-ruby-3.2) ✅
+- [`gitpod/workspace-ruby-3.3`](https://hub.docker.com/r/gitpod/workspace-ruby-3.3) ✅
 - [`gitpod/workspace-rust`](https://hub.docker.com/r/gitpod/workspace-rust) ✅
 - [`gitpod/workspace-elixir`](https://hub.docker.com/r/gitpod/workspace-elixir) ✅
 
@@ -71,7 +73,7 @@ Each contains a set of chunks: a common base, and a language, and includes Docke
 For images dedicated to Java, Node, Python and Ruby, their lifecycle generally works as follows:
 
 - If an image does not have a version in its name, we try to keep it at its latest stable version
-- If an image is versioned (like `workspace-python-3.12`), we'll support it until it reached End of Life
+- If an image is versioned (like `workspace-python-3.12`), we'll support it until it reaches End of Life
 
 ### 🎬 No upgrade planned
 

--- a/chunks/lang-ruby/chunk.yaml
+++ b/chunks/lang-ruby/chunk.yaml
@@ -8,3 +8,6 @@ variants:
   - name: "3.2"
     args:
       RUBY_VERSION: 3.2.2
+  - name: "3.3"
+    args:
+      RUBY_VERSION: 3.3.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -118,11 +118,16 @@ combiner:
       - base
       chunks:
         - lang-ruby:3.2
+    - name: ruby-3.3
+      ref:
+      - base
+      chunks:
+        - lang-ruby:3.3
     - name: ruby-3
       ref:
       - base
       chunks:
-        - lang-ruby:3.2
+        - lang-ruby:3.3
     - name: rust
       ref:
       - base


### PR DESCRIPTION
Ruby 3.3.0 has been releases, and we are introducing a new image flavor along with it. We're also bumping Ruby 3 to use 3.3 by default.

https://github.com/ruby/ruby/releases/tag/v3_3_0