### PR TITLE
Bump Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-02-09
+
+- Bump Rust to `1.76.0`
+
 ## 2024-01-09
 
 - Bump Rust to `1.75.0`

--- a/chunks/lang-rust/chunk.yaml
+++ b/chunks/lang-rust/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      RUST_VERSION: 1.75.0
+      RUST_VERSION: 1.76.0


### PR DESCRIPTION
## Description

Bumps Rust to https://github.com/rust-lang/rust/releases/tag/1.76.0
