### PR TITLE
Fix autofixes for python and ruby

### DIFF
--- a/.autofix/fixers/update-lang-python.js
+++ b/.autofix/fixers/update-lang-python.js
@@ -14,7 +14,7 @@ exports.register = async (fixers) => {
   const response = await fetch("https://raw.githubusercontent.com/endoflife-date/release-data/main/releases/python.json");
   const data = await response.json();
 
-  const versions = sortVersions(Object.keys(data));
+  const versions = sortVersions(Object.keys(data.versions));
 
   const patchVersionReplacements = {};
   for (const version of versions) {

--- a/.autofix/fixers/update-lang-ruby.js
+++ b/.autofix/fixers/update-lang-ruby.js
@@ -4,7 +4,7 @@ exports.register = async (fixers) => {
   const response = await fetch("https://raw.githubusercontent.com/endoflife-date/release-data/main/releases/ruby.json");
   const data = await response.json();
 
-  const versions = Object.keys(data);
+  const versions = Object.keys(data.versions);
 
   const patchVersionReplacements = {};
   for (const version of versions) {


### PR DESCRIPTION
Since the end of life version data format changed (see https://github.com/endoflife-date/release-data/issues/51), we need to adapt for our autofix to keep working.