### PR TITLE
Bump Rust to 1.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-03-27
+
+- Bump Rust to `1.77.0`
+
 ## 2024-02-11
 
 - Bump Go to `1.22.0`

--- a/chunks/lang-rust/chunk.yaml
+++ b/chunks/lang-rust/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      RUST_VERSION: 1.76.0
+      RUST_VERSION: 1.77.0


### PR DESCRIPTION
## Description
This PR bumps rust to 1.77.0, the latest stable release of Rust.
As the previous Rust version contains an ICE, this is fairly important.

## Related Issue(s)
N/A

## How to test
Run `rustc -V` in the gitpod terminal.

## Documentation
This does require https://www.gitpod.io/docs/introduction/languages/rust to be updated
```diff
Gitpod always comes with the latest available Rust toolchain pre-installed using [rustup](https://rustup.rs/). (As of this writing, the Rust version is
- 1.68.1.
+ 1.77.0.
```
However, either the repo has moved or I don't have access, so unfortunately I cannot create a new docs issue.

/hold