### PR TITLE
[docker] pin to v26.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-04-29
+
+- Temporarily pin the version of Docker. Refer to [19662](https://github.com/gitpod-io/gitpod/issues/19662#issuecomment-2083388559) for more detail.
+
 ## 2024-04-10
 
 - Deprecate `gitpod/workspace-ruby-3.0`

--- a/chunks/tool-docker/Dockerfile
+++ b/chunks/tool-docker/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
     $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt update \
-    && install-packages docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+    && install-packages docker-ce=5:26.0.1-1~ubuntu.22.04~jammy docker-ce-cli=5:26.0.1-1~ubuntu.22.04~jammy containerd.io docker-buildx-plugin
 
 RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.24.1/docker-compose-linux-$(uname -m) \
     && chmod +x /usr/local/bin/docker-compose && mkdir -p /usr/local/lib/docker/cli-plugins && \

--- a/tests/lang-java.yaml
+++ b/tests/lang-java.yaml
@@ -8,7 +8,7 @@
     stderr.indexOf("17.0.")    != -1
 - desc: it should have a functioning java 17 installed
   entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
-  command: [sdk default java 17.0.10.fx-zulu && java -version && mvn -v]
+  command: [sdk default java 17.0.11.fx-zulu && java -version && mvn -v]
   assert:
   - status == 0
   - stderr.indexOf('openjdk version \"17.') != -1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refer to https://github.com/gitpod-io/gitpod/issues/19662 for background, this is a temporary fix.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #19662 

## How to test
<!-- Provide steps to test this PR -->
From a Gitpod workspace in this repo, test with:
```bash
./build-combo.sh base
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
