### PR TITLE
Introduce Java 21 LTS

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -35,6 +35,7 @@
     workspace-mongodb: "2024.*"
     workspace-java-11: "2024.*"
     workspace-java-17: "2024.*"
+    workspace-java-21: "2024.*"
     workspace-yugabytedb: "2024.*"
     workspace-yugabytedb-preview: "2024.*"
     workspace-gitpod-dev: "2024.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -32,6 +32,7 @@ sync:
     - mongodb
     - java-11
     - java-17
+    - java-21
     - yugabytedb
     - yugabytedb-preview
     - gitpod-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-05-03
+
+- Introduce `workspace-java-21`
+
 ## 2024-04-29
 
 - Temporarily pin the version of Docker. Refer to [19662](https://github.com/gitpod-io/gitpod/issues/19662#issuecomment-2083388559) for more detail.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Each contains a set of chunks: a common base and a language / tool. Every image 
 - [`gitpod/workspace-go`](https://hub.docker.com/r/gitpod/workspace-go) ✅
 - [`gitpod/workspace-java-11`](https://hub.docker.com/r/gitpod/workspace-java-11) ✅
 - [`gitpod/workspace-java-17`](https://hub.docker.com/r/gitpod/workspace-java-17) ✅
+- [`gitpod/workspace-java-21`](https://hub.docker.com/r/gitpod/workspace-java-21) ✅
 - [`gitpod/workspace-node`](https://hub.docker.com/r/gitpod/workspace-node) ✅
 - [`gitpod/workspace-node-lts`](https://hub.docker.com/r/gitpod/workspace-node-lts) ✅
 - [`gitpod/workspace-node-18`](https://hub.docker.com/r/gitpod/workspace-node-18) ✅

--- a/chunks/lang-java/chunk.yaml
+++ b/chunks/lang-java/chunk.yaml
@@ -5,3 +5,6 @@ variants:
   - name: "17"
     args:
       JAVA_VERSION: 17.0.11.fx-zulu
+  - name: "21"
+    args:
+      JAVA_VERSION: 21.0.2.fx-zulu

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -173,6 +173,11 @@ combiner:
       - base
       chunks:
         - lang-java:17
+    - name: java-21
+      ref:
+      - base
+      chunks:
+        - lang-java:21
     - name: yugabytedb
       ref:
       - base

--- a/tests/lang-java.yaml
+++ b/tests/lang-java.yaml
@@ -5,7 +5,8 @@
   - status == 0
   - stderr.indexOf("OpenJDK")   != -1
   - stderr.indexOf("11.0.")   != -1 ||
-    stderr.indexOf("17.0.")    != -1
+    stderr.indexOf("17.0.")    != -1 ||
+    stderr.indexOf("21.0.")    != -1
 - desc: it should have a functioning java 17 installed
   entrypoint: [env, GITPOD_REPO_ROOT=/workspace, bash, -ci]
   command: [sdk default java 17.0.11.fx-zulu && java -version && mvn -v]


### PR DESCRIPTION
## Description

Adds Java 21 to keep up with the Zulu JDK LTS releases.

Adds the `lang-java:21` chunk as well as the `workspace-java-21` standalone image.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #1342

