### PR TITLE
Bump Rust to `1.78.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-05-03
+
+- Bump Rust to `1.78.0`
+
 ## 2024-04-29
 
 - Temporarily pin the version of Docker. Refer to [19662](https://github.com/gitpod-io/gitpod/issues/19662#issuecomment-2083388559) for more detail.

--- a/chunks/lang-rust/chunk.yaml
+++ b/chunks/lang-rust/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      RUST_VERSION: 1.77.2
+      RUST_VERSION: 1.78.0


### PR DESCRIPTION
## Description

Updates Rust to https://github.com/rust-lang/rust/releases/tag/1.78.0.
