### PR TITLE
[docker] downgrade docker-ce to 24.0.9

### DIFF
--- a/chunks/tool-docker/Dockerfile
+++ b/chunks/tool-docker/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
     $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt update \
-    && install-packages docker-ce=5:26.0.1-1~ubuntu.22.04~jammy docker-ce-cli=5:26.0.1-1~ubuntu.22.04~jammy containerd.io docker-buildx-plugin
+    && install-packages docker-ce=5:24.0.9-1~ubuntu.22.04~jammy docker-ce-cli=5:24.0.9-1~ubuntu.22.04~jammy containerd.io docker-buildx-plugin
 
 RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/v2.24.1/docker-compose-linux-$(uname -m) \
     && chmod +x /usr/local/bin/docker-compose && mkdir -p /usr/local/lib/docker/cli-plugins && \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This avoids limitations with extended attributes for tar files: https://docs.docker.com/engine/release-notes/25.0/#known-limitations

The problem manifests depending on extended attributes usage with some images. For example, from within Gitpod, run:

```
docker run curlimages/curl:8.1.2 -v -k https://example.com
docker: failed to register layer: lsetxattr user.overlay.origin /bin: operation not supported.
See 'docker run --help'.
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a
Related to https://github.com/gitpod-io/workspace-images/pull/1339

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
