### PR TITLE
Rust 1.79

### DIFF
--- a/chunks/lang-rust/chunk.yaml
+++ b/chunks/lang-rust/chunk.yaml
@@ -1,4 +1,4 @@
 variants:
   - name: "1"
     args:
-      RUST_VERSION: 1.78.0
+      RUST_VERSION: 1.79.0


### PR DESCRIPTION
## Description

Bump to https://github.com/rust-lang/rust/releases/tag/1.79.0
