### PR TITLE
feat: upgrade to llvm 18

### DIFF
--- a/chunks/lang-c/Dockerfile
+++ b/chunks/lang-c/Dockerfile
@@ -17,7 +17,8 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -
         clang-tidy-18 \
         gdb \
         lld-18 \
-        libclang-18-dev
+        libclang-18-dev \
+        clang-tools-18
 
 RUN sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-18/bin/clang 100 \
     && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-18/bin/clang++ 100 \

--- a/chunks/lang-c/Dockerfile
+++ b/chunks/lang-c/Dockerfile
@@ -8,21 +8,21 @@ ENV TRIGGER_REBUILD=1
 
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/jammy/ \
-    llvm-toolchain-jammy-17 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
+    llvm-toolchain-jammy-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null \
     && apt update \
     && install-packages \
-        clang-17 \
-        clangd-17 \
-        clang-format-17 \
-        clang-tidy-17 \
+        clang-18 \
+        clangd-18 \
+        clang-format-18 \
+        clang-tidy-18 \
         gdb \
-        lld-17
+        lld-18
 
-RUN sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-17/bin/clang 100 \
-    && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-17/bin/clang++ 100 \
-    && sudo update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-17 100 \
-    && sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-17 100 \
-    && sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-17 100 \
-    && sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-17 100
+RUN sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-18/bin/clang 100 \
+    && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-18/bin/clang++ 100 \
+    && sudo update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-18 100 \
+    && sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 100 \
+    && sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100 \
+    && sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-18 100
 
 USER gitpod

--- a/chunks/lang-c/Dockerfile
+++ b/chunks/lang-c/Dockerfile
@@ -16,7 +16,8 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -
         clang-format-18 \
         clang-tidy-18 \
         gdb \
-        lld-18
+        lld-18 \
+        libclang-18-dev
 
 RUN sudo update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-18/bin/clang 100 \
     && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-18/bin/clang++ 100 \


### PR DESCRIPTION
#fix https://github.com/gitpod-io/workspace-images/issues/1360

verified by `npx envinfo`

```console
  Utilities:
    Make: 4.3 - /usr/bin/make
    GCC: 11.4.0 - /usr/bin/gcc
    Git: 2.43.2 - /usr/bin/git
    Clang: 18.1.8 - /usr/bin/clang
```

two new packages was added for the asan support.
