### PR TITLE
Include `rlwrap` in the base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,6 +32,7 @@ RUN yes | unminimize \
         ssl-cert \
         fish \
         zsh \
+        rlwrap \
     && locale-gen en_US.UTF-8
 
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
## Description

For some reason, `rlwrap` is not being properly being set up and breaking `apt upgrade`. We include it now in the base image to hotfix the issue. This is more of a band-aid fix, and we should look into figuring it out properly.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-751

## How to test

### From Filip's 100% trustworthy Docker Hub entry

1. Create a workspace (either a full new one or a `gp validate` "debug" one) based off of `filiptronicek/workspace-full:rlwrap`
2. Make sure you can execute `sudo apt update && sudo apt upgrade` in the newly-created workspace

### From source

Beware, this **will** take a while

1. Open this repo in a workspace
1. `./build-combo.sh full`
3. `docker pull localhost:5000/dazzle:full`
4. Create a `.gitpod.yml` file in an `example` folder in the repo root
5. `gp validate --workspace-folder="/workspace/workspace-images/example"`
6. Make sure you can execute `sudo apt update && sudo apt upgrade` in the newly-created workspace
