### PR TITLE
Retry syncing date-tagged images 2 times

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -189,6 +189,7 @@ jobs:
         run: |
             sudo -E skopeo sync \
             --src yaml \
+            --retry-times=2 \
             --dest docker \
             /.github/promote-images.yml "${DH_IMAGE_REGISTRY}/gitpod"
 


### PR DESCRIPTION
## Description

Adds retries to potentially fix 502s we've [been seeing](https://linear.app/gitpod/issue/ENT-749/502-error-when-pushing-images-to-docker-hub-for-main-build-of).
