### PR TITLE
Remove dotnet 7

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -30,7 +30,6 @@
     workspace-rust: "2024.*"
     workspace-dotnet: "2024.*"
     workspace-dotnet-6: "2024.*"
-    workspace-dotnet-7: "2024.*"
     workspace-dotnet-8: "2024.*"
     workspace-postgres: "2024.*"
     workspace-mysql: "2024.*"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -27,7 +27,6 @@ sync:
     - rust
     - dotnet
     - dotnet-6
-    - dotnet-7
     - dotnet-8
     - postgres
     - mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-09-09
+
+- Remove dotnet 7 as a maintained image, it is no longer supported. Users requiring dotnet 7 are encouraged to do manage a custom image instead.
+
 ## 2024-08-15
 
 - Bump Go to `1.23.0`

--- a/chunks/tool-dotnet/chunk.yaml
+++ b/chunks/tool-dotnet/chunk.yaml
@@ -3,9 +3,6 @@ variants:
   - name: "6"
     args:
       DOTNET_VERSION: 6.0.125
-  - name: "7"
-    args:
-      DOTNET_VERSION: 7.0.404
   - name: "8"
     args:
       DOTNET_VERSION: 8.0.100

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -150,11 +150,6 @@ combiner:
         - full
       chunks:
         - tool-dotnet:6
-    - name: dotnet-7
-      ref:
-        - full
-      chunks:
-        - tool-dotnet:7
     - name: dotnet-8
       ref:
         - full

--- a/tests/tool-dotnet.yaml
+++ b/tests/tool-dotnet.yaml
@@ -4,5 +4,4 @@
   assert:
     - status == 0
     - stdout.indexOf("Microsoft.AspNetCore.App 8.0") != -1 ||
-      stdout.indexOf("Microsoft.AspNetCore.App 7.0") != -1 ||
       stdout.indexOf("Microsoft.AspNetCore.App 6.0") != -1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remote dotnet 7, it is no longer in support, users should use dotnet 6 or 8, which are LTS and still in support.

This will help reduce the # of chunks and combinations we build, as well as the # of images we push to GAR and sync to Docker Hub.

Related:
* I checked, and could not find other images we can remove, such as old versions of Python, Ruby, Node, and Java.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-749

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
