### PR TITLE
Keep syncing, even if errors are encountered

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -190,6 +190,7 @@ jobs:
             sudo -E skopeo sync \
             --src yaml \
             --retry-times=2 \
+            --keep-going \
             --dest docker \
             /.github/promote-images.yml "${DH_IMAGE_REGISTRY}/gitpod"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This will help keep synced images up-to-date on Docker Hub, so we don't accrue a backlog of unsynced content

> --keep-going If any errors occur during copying of images, those errors are logged and the process continues syncing rest of the images and finally fails at the end.

Ref: https://github.com/containers/skopeo/blob/main/docs/skopeo-sync.1.md

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-749

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
