### PR TITLE
Node: bump LTS and introduce Node 23

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -17,6 +17,7 @@
     workspace-node-18: "TIMESTAMP_TAG"
     workspace-node-20: "TIMESTAMP_TAG"
     workspace-node-22: "TIMESTAMP_TAG"
+    workspace-node-23: "TIMESTAMP_TAG"
     workspace-python: "TIMESTAMP_TAG"
     workspace-python-3.9: "TIMESTAMP_TAG"
     workspace-python-3.10: "TIMESTAMP_TAG"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -14,6 +14,7 @@ sync:
     - node-18
     - node-20
     - node-22
+    - node-23
     - python
     - python-3.9
     - python-3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2024-10-31 🎃
+
+- Bump the `workspace-node-lts` image to Node `22.11.0`
+- Bump the `workspace-node` image to Node `23.1.0`
+- Introduce `workspace-node-23`
+
 ## 2024-10-22
 
 - Deprecate `workspace-python-3.8`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Each contains a set of chunks: a common base and a language / tool. Every image 
 - [`gitpod/workspace-node-18`](https://hub.docker.com/r/gitpod/workspace-node-18) ✅
 - [`gitpod/workspace-node-20`](https://hub.docker.com/r/gitpod/workspace-node-20) ✅
 - [`gitpod/workspace-node-22`](https://hub.docker.com/r/gitpod/workspace-node-22) ✅
+- [`gitpod/workspace-node-23`](https://hub.docker.com/r/gitpod/workspace-node-23) ✅
 - [`gitpod/workspace-python`](https://hub.docker.com/r/gitpod/workspace-python) ✅
 - [`gitpod/workspace-python-3.9`](https://hub.docker.com/r/gitpod/workspace-python-3.9) ✅
 - [`gitpod/workspace-python-3.10`](https://hub.docker.com/r/gitpod/workspace-python-3.10) ✅

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -8,3 +8,6 @@ variants:
   - name: "22"
     args:
       NODE_VERSION: 22.11.0
+  - name: "23"
+    args:
+      NODE_VERSION: 23.1.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -12,7 +12,7 @@ combiner:
         - lang-c
         - lang-go:1.23
         - lang-java:11
-        - lang-node:20
+        - lang-node:22
         - tool-brew
     - name: c
       ref:
@@ -37,7 +37,7 @@ combiner:
         - lang-clojure
         - lang-go:1.23
         - lang-java:11
-        - lang-node:20
+        - lang-node:22
         - lang-python:3.12
         - lang-ruby:3.2
         - lang-rust:1
@@ -64,13 +64,13 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:22
+        - lang-node:23
         - tool-chrome
     - name: node-lts
       ref:
       - base
       chunks:
-        - lang-node:20
+        - lang-node:22
         - tool-chrome
     - name: node-18
       ref:
@@ -89,6 +89,12 @@ combiner:
       - base
       chunks:
         - lang-node:22
+        - tool-chrome
+    - name: node-23
+      ref:
+      - base
+      chunks:
+        - lang-node:23
         - tool-chrome
     - name: python
       ref:
@@ -198,7 +204,7 @@ combiner:
         - lang-clojure
         - lang-go:1.23
         - lang-java:11
-        - lang-node:20
+        - lang-node:22
         - lang-ruby:3.2
         - lang-rust:1
         - tool-brew
@@ -213,7 +219,7 @@ combiner:
         - lang-clojure
         - lang-go:1.23
         - lang-java:11
-        - lang-node:20
+        - lang-node:22
         - lang-ruby:3.2
         - lang-rust:1
         - tool-brew

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -5,7 +5,8 @@
   - status == 0
   - stdout.indexOf("v18")  != -1 ||
     stdout.indexOf("v20")  != -1 ||
-    stdout.indexOf("v22")  != -1
+    stdout.indexOf("v22")  != -1 ||
+    stdout.indexOf("v23")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
## Description

Last week, Node 22 became the active LTS release and Node 23 was introduced. Hence, this PR:
- introduces the `workspace-node-23`
- bumps `workspace-node` to node 23
- bumps `workspace-node-lts` to node 22
