### PR TITLE
Do no promote latest Dockerhub images every Monday

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -2,8 +2,8 @@ name: Publish latest images to Docker Hub
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 10 * * MON"
+  # schedule:
+  #   - cron: "0 10 * * MON"
 
 jobs:
   # Sync the 'latest' tag from GAR to Docker Hub


### PR DESCRIPTION
## Description

For a while now, we've only run the workflow manually (see [related internal Slack thread](https://gitpod.slack.com/archives/C01RC164G48/p1715011780302849?thread_ts=1714874731.424599&cid=C01RC164G48)). This makes the change more permanent to not force us to disable the workflow whenever we don't use it.
