### PR TITLE
Bump base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,39 +1,39 @@
 FROM buildpack-deps:jammy@sha256:9c6387be70924dc253a6c5594fd11bf8c90a19528442ee8b0b4040362bf1a662
 
 # Dazzle does not rebuild a layer until one of its lines are changed. Increase this counter to rebuild this layer.
-ENV TRIGGER_REBUILD=1
+ENV TRIGGER_REBUILD=2
 
 COPY install-packages upgrade-packages /usr/bin/
 
 ### base ###
 RUN yes | unminimize \
     && install-packages \
-        zip \
-        unzip \
-        bash-completion \
-        build-essential \
-        ninja-build \
-        clang \
-        htop \
-        iputils-ping \
-        jq \
-        less \
-        locales \
-        man-db \
-        nano \
-        ripgrep \
-        software-properties-common \
-        sudo \
-        stow \
-        time \
-        emacs-nox \
-        vim \
-        multitail \
-        lsof \
-        ssl-cert \
-        fish \
-        zsh \
-        rlwrap \
+    zip \
+    unzip \
+    bash-completion \
+    build-essential \
+    ninja-build \
+    clang \
+    htop \
+    iputils-ping \
+    jq \
+    less \
+    locales \
+    man-db \
+    nano \
+    ripgrep \
+    software-properties-common \
+    sudo \
+    stow \
+    time \
+    emacs-nox \
+    vim \
+    multitail \
+    lsof \
+    ssl-cert \
+    fish \
+    zsh \
+    rlwrap \
     && locale-gen en_US.UTF-8
 
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This should fix:
```
│    Library     │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                             │
├────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────────┤
│ linux-libc-dev │ CVE-2024-26800 │ HIGH     │ fixed  │ 5.15.0-124.134    │ 5.15.0-125.135 │ kernel: tls: fix use-after-free on failed backlog decryption │
│                │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-26800                   │
│                ├────────────────┤          │        │                   │                ├──────────────────────────────────────────────────────────────┤
│                │ CVE-2024-43882 │          │        │                   │                │ kernel: exec: Fix ToCToU between perm check and set-uid/gid  │
│                │                │          │        │                   │                │ usage                                                        │
│                │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-43882
```

We still have a vulnerability with docker compose, but, need to update https://github.com/gitpod-io/buildkit/pull/1 before we can update docker compose here.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to CLC-306

## How to test
<!-- Provide steps to test this PR -->
This vulnerability should no longer appear when the scan is done

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
