### PR TITLE
[lang-rust] don't install deprecated components

### DIFF
--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -12,7 +12,7 @@ ENV RUST_VERSION=${RUST_VERSION}
 ENV PATH=$HOME/.cargo/bin:$PATH
 
 RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain ${RUST_VERSION} \
-        -c rls rust-analysis rust-src rustfmt clippy \
+        -c rust-analyzer rust-src rustfmt clippy \
     && for cmp in rustup cargo; do rustup completions bash "$cmp" > "$HOME/.local/share/bash-completion/completions/$cmp"; done \
     && cargo install cargo-watch cargo-edit cargo-workspaces \
     && rm -rf "$HOME/.cargo/registry" # This registry cache is now useless as we change the CARGO_HOME path to `/workspace`

--- a/chunks/lang-rust/Dockerfile
+++ b/chunks/lang-rust/Dockerfile
@@ -12,7 +12,7 @@ ENV RUST_VERSION=${RUST_VERSION}
 ENV PATH=$HOME/.cargo/bin:$PATH
 
 RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain ${RUST_VERSION} \
-        -c rust-analyzer rust-src rustfmt clippy \
+        -c rust-analyzer -c rust-src -c rustfmt -c clippy \
     && for cmp in rustup cargo; do rustup completions bash "$cmp" > "$HOME/.local/share/bash-completion/completions/$cmp"; done \
     && cargo install cargo-watch cargo-edit cargo-workspaces \
     && rm -rf "$HOME/.cargo/registry" # This registry cache is now useless as we change the CARGO_HOME path to `/workspace`


### PR DESCRIPTION
## Description


The `rust-analysis` and `rls` components are no longer installable. I've replaced them with `rust-analyzer` as the new LSP

See https://rust-lang.github.io/rustup/concepts/components.html#previous-components

## How to test

The build shall pass