### PR TITLE
✨ Add Java 25 LTS and remove Java 23 EOL

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -38,7 +38,7 @@
     workspace-java-11: "TIMESTAMP_TAG"
     workspace-java-17: "TIMESTAMP_TAG"
     workspace-java-21: "TIMESTAMP_TAG"
-    workspace-java-23: "TIMESTAMP_TAG"
+    workspace-java-25: "TIMESTAMP_TAG"
     workspace-yugabytedb: "TIMESTAMP_TAG"
     workspace-yugabytedb-preview: "TIMESTAMP_TAG"
     workspace-gitpod-dev: "TIMESTAMP_TAG"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -35,7 +35,7 @@ sync:
     - java-11
     - java-17
     - java-21
-    - java-23
+    - java-25
     - yugabytedb
     - yugabytedb-preview
     - gitpod-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2025-09-25
+
+- Introduce `workspace-java-25`
+
 ## 2025-05-26
 
 - Bump Rust to `1.87.0`
@@ -34,9 +38,6 @@ A curated, chronologically ordered list of notable changes in [Gitpod's default 
 
 - Bump Docker in base image to `27.3.1`
 
-## 2024-11-11
-
-- Introduce `workspace-java-23`
 
 ## 2024-10-31 🎃
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each contains a set of chunks: a common base and a language / tool. Every image 
 - [`gitpod/workspace-java-11`](https://hub.docker.com/r/gitpod/workspace-java-11) ✅
 - [`gitpod/workspace-java-17`](https://hub.docker.com/r/gitpod/workspace-java-17) ✅
 - [`gitpod/workspace-java-21`](https://hub.docker.com/r/gitpod/workspace-java-21) ✅
-- [`gitpod/workspace-java-21`](https://hub.docker.com/r/gitpod/workspace-java-23) ✅
+- [`gitpod/workspace-java-25`](https://hub.docker.com/r/gitpod/workspace-java-25) ✅
 - [`gitpod/workspace-node`](https://hub.docker.com/r/gitpod/workspace-node) ✅
 - [`gitpod/workspace-node-lts`](https://hub.docker.com/r/gitpod/workspace-node-lts) ✅
 - [`gitpod/workspace-node-18`](https://hub.docker.com/r/gitpod/workspace-node-18) ✅

--- a/chunks/lang-java/chunk.yaml
+++ b/chunks/lang-java/chunk.yaml
@@ -8,6 +8,6 @@ variants:
   - name: "21"
     args:
       JAVA_VERSION: 21.0.8.fx-zulu
-  - name: "23"
+  - name: "25"
     args:
-      JAVA_VERSION: 23.0.2.fx-zulu
+      JAVA_VERSION: 25.fx-zulu

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -196,11 +196,11 @@ combiner:
       - base
       chunks:
         - lang-java:21
-    - name: java-23
+    - name: java-25
       ref:
       - base
       chunks:
-        - lang-java:23
+        - lang-java:25
     - name: yugabytedb
       ref:
       - base


### PR DESCRIPTION
## Description
Introduce Java 25 LTS version and removes Java 23 which has reached its End of life support

/hold
