### PR TITLE
Block npx and disable npm scripts in Node.js workspace image

### DIFF
--- a/chunks/lang-node/Dockerfile
+++ b/chunks/lang-node/Dockerfile
@@ -20,3 +20,12 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh |
     && echo ". ~/.nvm/nvm-lazy.sh"  >> /home/gitpod/.bashrc.d/50-node
 # above, we are adding the lazy nvm init to .bashrc, because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
 COPY --chown=gitpod:gitpod nvm-lazy.sh /home/gitpod/.nvm/nvm-lazy.sh
+
+RUN sudo rm -f /usr/bin/npx /usr/local/bin/npx && \
+    echo '#!/bin/sh' | sudo tee /usr/local/bin/npx && \
+    echo 'echo "npx is disabled for security reasons. Use explicit package installation instead." >&2' | sudo tee -a /usr/local/bin/npx && \
+    echo 'exit 1' | sudo tee -a /usr/local/bin/npx && \
+    sudo chmod +x /usr/local/bin/npx
+
+RUN npm config set ignore-scripts true --location=user && \
+    echo 'ignore-scripts true' >> /home/gitpod/.yarnrc


### PR DESCRIPTION
## Summary
Add security hardening to the Node.js workspace image by:
- Disabling npx command to prevent arbitrary package execution
- Setting ignore-scripts=true for npm and yarn to block lifecycle scripts

This prevents potential security risks from running untrusted scripts during package installation.

## Changes
- Modified `chunks/lang-node/Dockerfile` to disable npx and set npm/yarn to ignore scripts

## Test plan
- [ ] Build the Node.js workspace image successfully
- [ ] Verify npx command is disabled and returns an error
- [ ] Verify npm and yarn respect the ignore-scripts setting
- [ ] Verify existing functionality still works with these security measures

🤖 Generated with [Claude Code](https://claude.com/claude-code)