### PR TITLE
chore: pin GitHub Actions to SHA (PDE-218)

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
 
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # pin@v5
       with:
         node-version: "22.x"
 

--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout workspace-images
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
         with:
           repository: gitpod-io/workspace-images
 
@@ -61,13 +61,13 @@ jobs:
           echo "{}" > $SKOPEO_AUTH_DIR/auth
 
       - name: ☁️ Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3.0.1
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # pin@v3.0.1
         with:
           version: 393.0.0
 
       - name: 🔐 Authenticate to Google Cloud
         id: "auth"
-        uses: google-github-actions/auth@v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # pin@v3.0.0
         with:
           token_format: "access_token"
           workload_identity_provider: ${{env.WORKLOAD_IDENTITY_POOL_ID}}
@@ -106,7 +106,7 @@ jobs:
       - name: The release was successful
         id: slack-success
         if: needs.promote-latest.result == 'success'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.RELEASE_NOTIFY_WEBHOOK }}
@@ -116,7 +116,7 @@ jobs:
       - name: The release was not successful
         id: slack-failure
         if: needs.promote-latest.result != 'success'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.RELEASE_NOTIFY_WEBHOOK }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: cschleiden/actions-linter@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
+      - uses: cschleiden/actions-linter@1282bc2497ca41be7846b12393d54945a7d63267 # pin@v1
         with:
           workflows: '[".github/workflows/*.yaml"]'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,9 @@ jobs:
           df -h
 
       - name: 📥 Checkout workspace-images
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
+        with:
+          repository: gitpod-io/workspace-images
 
       - name: 🔧 Setup pre-commit
         run: |
@@ -55,13 +57,13 @@ jobs:
       # A hack as GH action does not allow you to force override cache storing if there was a cache hit
       # https://github.com/actions/cache/issues/628#issuecomment-986118455
       - name: 🗄️ Force Save Registry Cache Per Sha
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4
         with:
           path: ~/registry
           key: ${{ runner.os }}-pull-request-cache-${{ github.sha }}
 
       - name: 🗄️ Restore Registry Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # pin@v4
         with:
           path: ~/registry
           key: ${{ runner.os }}-pull-request-cache-${{ github.sha }}

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout workspace-images
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
         with:
           repository: gitpod-io/workspace-images
 
@@ -104,13 +104,13 @@ jobs:
           sudo chmod +777 /run/buildkit/buildkitd.sock
 
       - name: ☁️ Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3.0.1
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # pin@v3.0.1
         with:
           version: 393.0.0
 
       - name: 🔐 Authenticate to Google Cloud
         id: "auth"
-        uses: google-github-actions/auth@v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # pin@v3.0.0
         with:
           token_format: "access_token"
           access_token_lifetime: "43200s"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
 
       - name: add label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # pin@v1
         with:
           labels: "team: team-experience"


### PR DESCRIPTION
Pin all external GitHub Actions to specific commit SHAs for supply chain security.

## Changes

- `actions/cache@v4` → pinned to SHA
- `actions/checkout@v5` → pinned to SHA
- `actions-ecosystem/action-add-labels@v1` → pinned to SHA
- `actions/setup-node@v5` → pinned to SHA
- `cschleiden/actions-linter@v1` → pinned to SHA
- `google-github-actions/auth@v3.0.0` → pinned to SHA
- `google-github-actions/setup-gcloud@v3.0.1` → pinned to SHA
- `slackapi/slack-github-action@v2.1.1` → pinned to SHA

## Exceptions

Internal Gitpod workflows (not pinned to SHA):
- `gitpod-io/gce-github-runner/.github/workflows/create-vm.yml@main`
- `gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@main`

## Related

- Part of [PDE-138](https://linear.app/ona-team/issue/PDE-138)
- Closes [PDE-218](https://linear.app/ona-team/issue/PDE-218)