### PR TITLE
Change runner to ubuntu-latest-16-cores to fix main builds running out of storage (and taking too long)

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -13,7 +13,7 @@ jobs:
   # Click New environment, set the name production, and click Configure environment.
   # Check the "Required reviewers" box and enter at least one user or team name.
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-sync
       cancel-in-progress: true


### PR DESCRIPTION
## Description
gitpod-io/workspace-images is already allow-listed for this runner group :heavy_check_mark: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
