### PR TITLE
feat: Add Node.js v24 support and set as default

### DIFF
--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -18,6 +18,7 @@
     workspace-node-20: "TIMESTAMP_TAG"
     workspace-node-22: "TIMESTAMP_TAG"
     workspace-node-23: "TIMESTAMP_TAG"
+    workspace-node-24: "TIMESTAMP_TAG"
     workspace-python: "TIMESTAMP_TAG"
     workspace-python-3.10: "TIMESTAMP_TAG"
     workspace-python-3.11: "TIMESTAMP_TAG"

--- a/.github/promote-images.yml
+++ b/.github/promote-images.yml
@@ -19,6 +19,7 @@
     workspace-node-22: "TIMESTAMP_TAG"
     workspace-node-23: "TIMESTAMP_TAG"
     workspace-node-24: "TIMESTAMP_TAG"
+    workspace-node-25: "TIMESTAMP_TAG"
     workspace-python: "TIMESTAMP_TAG"
     workspace-python-3.10: "TIMESTAMP_TAG"
     workspace-python-3.11: "TIMESTAMP_TAG"

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -16,6 +16,7 @@ sync:
     - node-22
     - node-23
     - node-24
+    - node-25
     - python
     - python-3.10
     - python-3.11

--- a/.github/sync-containers.yml
+++ b/.github/sync-containers.yml
@@ -15,6 +15,7 @@ sync:
     - node-20
     - node-22
     - node-23
+    - node-24
     - python
     - python-3.10
     - python-3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ A curated, chronologically ordered list of notable changes in [Gitpod's default 
 
 ## 2026-02-12
 
-- Introduce `gitpod/workspace-node-24`
+- Introduce `gitpod/workspace-node-24` and `gitpod/workspace-node-25`
 - Bump `gitpod/workspace-node-lts` and `gitpod/workspace-full` to Node.js 24
-- Bump `gitpod/workspace-node` to Node.js 24
+- Bump `gitpod/workspace-node` to Node.js 25
 
 ## 2026-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A curated, chronologically ordered list of notable changes in [Gitpod's default workspace images](https://hub.docker.com/u/gitpod).
 
+## 2026-02-12
+
+- Introduce `gitpod/workspace-node-24`
+- Bump `gitpod/workspace-node-lts` and `gitpod/workspace-full` to Node.js 24
+- Bump `gitpod/workspace-node` to Node.js 24
+
 ## 2026-01-20
 
 - Remove `gitpod/workspace-python-3.9` (Python 3.9 reached EOL October 2025)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Each contains a set of chunks: a common base and a language / tool. Every image 
 - [`gitpod/workspace-node-22`](https://hub.docker.com/r/gitpod/workspace-node-22) ✅
 - [`gitpod/workspace-node-23`](https://hub.docker.com/r/gitpod/workspace-node-23) ✅
 - [`gitpod/workspace-node-24`](https://hub.docker.com/r/gitpod/workspace-node-24) ✅
+- [`gitpod/workspace-node-25`](https://hub.docker.com/r/gitpod/workspace-node-25) ✅
 - [`gitpod/workspace-python`](https://hub.docker.com/r/gitpod/workspace-python) ✅
 - [`gitpod/workspace-python-3.10`](https://hub.docker.com/r/gitpod/workspace-python-3.10) ✅
 - [`gitpod/workspace-python-3.11`](https://hub.docker.com/r/gitpod/workspace-python-3.11) ✅

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Each contains a set of chunks: a common base and a language / tool. Every image 
 - [`gitpod/workspace-node-20`](https://hub.docker.com/r/gitpod/workspace-node-20) ✅
 - [`gitpod/workspace-node-22`](https://hub.docker.com/r/gitpod/workspace-node-22) ✅
 - [`gitpod/workspace-node-23`](https://hub.docker.com/r/gitpod/workspace-node-23) ✅
+- [`gitpod/workspace-node-24`](https://hub.docker.com/r/gitpod/workspace-node-24) ✅
 - [`gitpod/workspace-python`](https://hub.docker.com/r/gitpod/workspace-python) ✅
 - [`gitpod/workspace-python-3.10`](https://hub.docker.com/r/gitpod/workspace-python-3.10) ✅
 - [`gitpod/workspace-python-3.11`](https://hub.docker.com/r/gitpod/workspace-python-3.11) ✅

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -14,3 +14,6 @@ variants:
   - name: "24"
     args:
       NODE_VERSION: 24.13.0
+  - name: "25"
+    args:
+      NODE_VERSION: 25.6.1

--- a/chunks/lang-node/chunk.yaml
+++ b/chunks/lang-node/chunk.yaml
@@ -11,3 +11,6 @@ variants:
   - name: "23"
     args:
       NODE_VERSION: 23.11.1
+  - name: "24"
+    args:
+      NODE_VERSION: 24.13.0

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -90,19 +90,19 @@ combiner:
       chunks:
         - lang-node:22
         - tool-chrome
-    - name: "node-23"
+    - name: node-23
       ref:
       - base
       chunks:
         - lang-node:23
         - tool-chrome
-    - name: "node-24"
+    - name: node-24
       ref:
       - base
       chunks:
         - lang-node:24
         - tool-chrome
-    - name: "node-25"
+    - name: node-25
       ref:
       - base
       chunks:

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -64,7 +64,7 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:24
+        - lang-node:25
         - tool-chrome
     - name: node-lts
       ref:
@@ -101,6 +101,12 @@ combiner:
       - base
       chunks:
         - lang-node:24
+        - tool-chrome
+    - name: "node-25"
+      ref:
+      - base
+      chunks:
+        - lang-node:25
         - tool-chrome
     - name: python
       ref:

--- a/dazzle.yaml
+++ b/dazzle.yaml
@@ -37,7 +37,7 @@ combiner:
         - lang-clojure
         - lang-go:1.24
         - lang-java:11
-        - lang-node:22
+        - lang-node:24
         - lang-python:3.13
         - lang-ruby:3.2
         - lang-rust:1
@@ -64,13 +64,13 @@ combiner:
       ref:
       - base
       chunks:
-        - lang-node:23
+        - lang-node:24
         - tool-chrome
     - name: node-lts
       ref:
       - base
       chunks:
-        - lang-node:22
+        - lang-node:24
         - tool-chrome
     - name: node-18
       ref:
@@ -90,11 +90,17 @@ combiner:
       chunks:
         - lang-node:22
         - tool-chrome
-    - name: node-23
+    - name: "node-23"
       ref:
       - base
       chunks:
         - lang-node:23
+        - tool-chrome
+    - name: "node-24"
+      ref:
+      - base
+      chunks:
+        - lang-node:24
         - tool-chrome
     - name: python
       ref:

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -6,7 +6,8 @@
   - stdout.indexOf("v18")  != -1 ||
     stdout.indexOf("v20")  != -1 ||
     stdout.indexOf("v22")  != -1 ||
-    stdout.indexOf("v23")  != -1
+    stdout.indexOf("v23")  != -1 ||
+    stdout.indexOf("v24")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]

--- a/tests/lang-node.yaml
+++ b/tests/lang-node.yaml
@@ -7,7 +7,8 @@
     stdout.indexOf("v20")  != -1 ||
     stdout.indexOf("v22")  != -1 ||
     stdout.indexOf("v23")  != -1 ||
-    stdout.indexOf("v24")  != -1
+    stdout.indexOf("v24")  != -1 ||
+    stdout.indexOf("v25")  != -1
 - desc: it should have yarn
   command: [yarn --version]
   entrypoint: [bash, -i, -c]


### PR DESCRIPTION
Fixes CLC-2222

Add Node.js v24 (24.13.0) variant and use it as the default, replacing Node 22.

Changes:
- Add Node 24 variant in `chunks/lang-node/chunk.yaml`
- Update default workspace image to use Node 24
- Update `node-lts` image to Node 24
- Add dedicated `node-24` image combination

Original author: Simeon Huang (@librehat)
Cherry-picked from librehat/workspace-images@1279545

Fixes #1958